### PR TITLE
Linker Toolchain: Refactor forwarding of arguments from linker to librarian

### DIFF
--- a/src/ld.cxx
+++ b/src/ld.cxx
@@ -36,19 +36,18 @@ DWORD LdInvocation::InvokeToolchain() {
         std::string const imp_lib_name = link_run.get_implib_name();
         std::string dll_name = link_run.get_mangled_out();
         std::string const abs_out_imp_lib_name = imp_lib_name + ".dll-abs.lib";
-        std::string const def_file = link_run.get_def_file();
-        std::string def_line = "-def";
-        def_line += !def_file.empty() ? ":" + def_file : "";
+        std::string def = "-def ";
+        std::string piped_args = link_run.get_lib_link_args();
         // create command line to generate new import lib
-        this->rpath_executor = ExecuteCommand(
-            "lib.exe",
-            LdInvocation::ComposeCommandLists({
-                {def_line, "-name:" + dll_name, "-out:" + abs_out_imp_lib_name},
-                {link_run.get_rsp_file()},
-                this->obj_args,
-                this->lib_args,
-                this->lib_dir_args,
-            }));
+        this->rpath_executor =
+            ExecuteCommand("lib.exe", LdInvocation::ComposeCommandLists({
+                                          {def, piped_args, "-name:" + dll_name,
+                                           "-out:" + abs_out_imp_lib_name},
+                                          {link_run.get_rsp_file()},
+                                          this->obj_args,
+                                          this->lib_args,
+                                          this->lib_dir_args,
+                                      }));
         this->rpath_executor.Execute();
         DWORD const err_code = this->rpath_executor.Join();
         if (err_code != 0) {

--- a/src/linker_invocation.h
+++ b/src/linker_invocation.h
@@ -22,6 +22,7 @@ class LinkerInvocation {
     std::string get_implib_name();
     std::string get_def_file();
     std::string get_rsp_file();
+    std::string get_lib_link_args();
 
    private:
     std::string line_;
@@ -34,4 +35,10 @@ class LinkerInvocation {
     StrList libs_;
     StrList objs_;
     bool is_exe_;
+    std::map<std::string, StrList> piped_args_ = {
+        {"def", {}},          {"export", {}},    {"include", {}},
+        {"libpath", {}},      {"ltcg", {}},      {"machine", {}},
+        {"nodefaultlib", {}}, {"subsystem", {}}, {"verbose", {}},
+        {"wx", {}},
+    };
 };


### PR DESCRIPTION
General workflow for generating an "rpath'd" import library:

Run the linker (link.exe) and allow it to produce a dll and import library.

Parse the linker command line, and extract what we think we need. Pass that to the librarian (lib) along with the absolute path to the dll as the name. 

Replace the old import lib with the new one.

Previously the wrapper had an ad-hoc approach to forwarding arguments from the linker to the librarian.
However this resulted in cases where crucial arguments that the librarian needs to be aware of to get dropped from the CLI.

This PR:

Adds a map including every argument that is valid for both the linker and librarian (and makes sense to forward for our case), and checks that map against the linker CLI to ensure we're forwarding all arguments verbatim (with handling for quoting).

