### PR TITLE
Utils: Expand functionality and refactor join behavior

### DIFF
--- a/src/utils.cxx
+++ b/src/utils.cxx
@@ -403,6 +403,22 @@ void debug(char * dbgStmt, int len) {
     debug(std::string(dbgStmt, len));
 }
 
+bool isCommandArg(const std::string &arg, const std::string &command)
+{
+    const std::string slash_opt = "/"+command;
+    const std::string dash_opt = "-"+command;
+    return startswith(arg, slash_opt) || startswith(arg, dash_opt);
+}
+
+void normalArg(std::string &arg)
+{
+    // first normalize capitalization
+    lower(arg);
+    // strip leading / and -
+    arg = strip(strip(arg, "-"), "/");
+}
+
+
 std::string reportLastError()
 {
     DWORD error = GetLastError();

--- a/src/utils.cxx
+++ b/src/utils.cxx
@@ -141,8 +141,12 @@ std::string join(const StrList &args, const std::string &join_char)
     for(std::string arg : args) {
        joined_path += arg + join_char;
     }
-    // Remove trailing space
-    joined_path.pop_back();
+    // Remove trailing token
+    const size_t last_token_pos = joined_path.rfind(join_char);
+    if(last_token_pos != std::string::npos)
+    {
+        joined_path.erase(last_token_pos, joined_path.length());
+    }
     return joined_path;
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -160,6 +160,10 @@ void debug(std::string dbgStmt);
 
 void debug(char * dbgStmt, int len);
 
+bool isCommandArg(const std::string &arg, const std::string &opt);
+
+void normalArg(std::string &arg);
+
 /**
  * Library Searching utility class
  *  Collection of heuristics and logic surrounding library


### PR DESCRIPTION
Adds two new utilities:

* `isCommandArg`: takes a string and a command option and determines if the string is the command option

* `normalArg`: Normalizes a command line argument for easier parsing (lowercase, strip leading `\` and `-` characters, etc)

and refactors `join`'s behavior, instead of stripping a trailing space, we remove the dangling separator, no matter what it is.