### PR TITLE
WinRPath: Special Case Spack Libs

### DIFF
--- a/src/utils.cxx
+++ b/src/utils.cxx
@@ -555,6 +555,14 @@ bool hasPathCharacters(const std::string &name) {
     return false;
 }
 
+bool SpackInstalledLib(const std::string &lib) {
+    const std::string prefix = GetSpackEnv("SPACK_INSTALL_PREFIX");
+    if (prefix.empty()) {
+        debug("Unable to determine Spack install prefix, SPACK_INSTALL_PREFIX unset");
+        return false;
+    }
+    return startswith(lib, prefix);
+}
 
 LibraryFinder::LibraryFinder() : search_vars{"SPACK_RELOCATE_PATH"} {}
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -147,6 +147,8 @@ void replace_path_characters(char in[], int len);
 
 void replace_special_characters(char in[], int len);
 
+bool SpackInstalledLib(const std::string &lib);
+
 // File and File handle helpers //
 
 // Returns File offset given RVA

--- a/src/winrpath.cxx
+++ b/src/winrpath.cxx
@@ -829,6 +829,9 @@ bool LibRename::RenameDll(char* name_loc, const std::string &dll_path)
         }
     }
     else {
+        if(SpackInstalledLib(dll_path)) {
+            return true;
+        }
         std::string file_name = basename(dll_path);
         if(file_name.empty()) {
             std::cerr << "Unable to extract filename from dll for relocation" << "\n";


### PR DESCRIPTION
When performing stage -> install prefix relocation, any DLL referenced by the library we're relocating that is Spack derived and not part of the package we're installing already has the appropriate RPath and therefore does not require relocation. Add logic to special case those DLLs by checking an environment variable defining the spack install prefix against the install prefix of the DLLs were considering for relocation.