### PR TITLE
utils: Strip padding && Special case Spack Libraries

### DIFF
--- a/src/utils.cxx
+++ b/src/utils.cxx
@@ -508,6 +508,20 @@ int get_padding_length(const std::string& name) {
     return count;
 }
 
+std::string strip_padding(const std::string &lib)
+{
+    // One of the padding characters is a legitimate
+    // path separator
+    int pad_len = get_padding_length(lib)-1;
+    // Capture the drive and drive separator
+    std::string::const_iterator p = lib.cbegin();
+    std::string::const_iterator e = lib.cbegin()+2;
+    std::string stripped_drive(p, e);
+    e = e + pad_len;
+    std::string path_remainder(e, lib.end());
+    return stripped_drive + path_remainder;
+}
+
 /**
  * Mangles a string representing a path to have no path characters
  *  instead path characters (i.e. \\, :, etc) are replaced with
@@ -558,7 +572,8 @@ bool SpackInstalledLib(const std::string& lib) {
             "unset");
         return false;
     }
-    return startswith(lib, prefix);
+    std::string stripped_lib = strip_padding(lib);
+    startswith(stripped_lib, prefix);
 }
 
 LibraryFinder::LibraryFinder() : search_vars{"SPACK_RELOCATE_PATH"} {}

--- a/src/utils.cxx
+++ b/src/utils.cxx
@@ -541,7 +541,6 @@ std::string mangle_name(const std::string& name) {
  *  \param name string to check for path characters
  */
 bool hasPathCharacters(const std::string& name) {
-    using PathCharMap = std::map<char, char>::const_iterator;
     for (auto it = path_to_special_characters.begin();
          it != path_to_special_characters.end(); ++it) {
         if (!(name.find(it->first) == std::string::npos)) {
@@ -549,6 +548,17 @@ bool hasPathCharacters(const std::string& name) {
         }
     }
     return false;
+}
+
+bool SpackInstalledLib(const std::string& lib) {
+    const std::string prefix = GetSpackEnv("SPACK_INSTALL_PREFIX");
+    if (prefix.empty()) {
+        debug(
+            "Unable to determine Spack install prefix, SPACK_INSTALL_PREFIX "
+            "unset");
+        return false;
+    }
+    return startswith(lib, prefix);
 }
 
 LibraryFinder::LibraryFinder() : search_vars{"SPACK_RELOCATE_PATH"} {}

--- a/src/utils.h
+++ b/src/utils.h
@@ -172,6 +172,8 @@ void replace_path_characters(char* path, size_t len);
 
 void replace_special_characters(char* mangled, size_t len);
 
+bool SpackInstalledLib(const std::string &lib);
+
 // File and File handle helpers //
 
 // Returns File offset given RVA

--- a/src/winrpath.cxx
+++ b/src/winrpath.cxx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: (Apache-2.0 OR MIT)
  */
 #include <cstdio>
-#include <cstdio>
+#include <stdio.h>
 #include <windows.h>  // NOLINT
 #include "winrpath.h"
 #include <fileapi.h>
@@ -82,6 +82,9 @@ bool LibRename::RenameDll(char* name_loc, const std::string& dll_path) const {
             _snprintf(name_loc, sizeof(long_sigil) - 1, "%s", long_sigil);
         }
     } else {
+        if (SpackInstalledLib(dll_path)) {
+            return true;
+        }
         std::string const file_name = basename(dll_path);
         if (file_name.empty()) {
             std::cerr << "Unable to extract filename from dll for relocation"


### PR DESCRIPTION
* Adds a method to support removing the padding we add to our "RPath" paths for easier comparison with paths derived from the local filesystem/environment

* When performing stage -> install prefix relocation, any DLL referenced by the library we're relocating that is Spack derived and not part of the package we're installing already has the appropriate RPath and therefore does not require relocation. Add logic to special case those DLLs by checking an environment variable defining the spack install prefix against the install prefix of the DLLs were considering for relocation.