### PR TITLE
Long Path Support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,9 @@ jobs:
       - name: Remove Git Bash tools
         run: |
           rmdir /s /q "C:\Program Files\Git\usr"
+      - name: enable 8.3 names
+        run: |
+          fsutil 8dot3name set 0
       - name: "Test RPath"
         run: |
           test\setup_and_drive_test.bat

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 
 # Vscode 
 /.vscode/
+
+# ignore patch files
+*.patch

--- a/Makefile
+++ b/Makefile
@@ -147,13 +147,13 @@ test_long_paths: build_and_check_test_sample
 	xcopy /E "test\src file" tmp\tmp\verylongdirectoryname\evenlongersubdirectoryname
 	xcopy test\main.cxx tmp\tmp\verylongdirectoryname\evenlongersubdirectoryname
 	cd tmp\tmp\verylongdirectoryname\evenlongersubdirectoryname
-	rename calc.cxx verylongfilepathnamethatwillmostlikelybegreaterthanonehundredandfourtyfourcharacters.cxx
+	rename calc.cxx verylongfilepathnamethatwilldefinitelybegreaterthanonehundredandfourtyfourcharacters.cxx
 	copy ..\..\..\..\cl.exe cl.exe
 	-@ if NOT EXIST "link.exe" mklink link.exe cl.exe
-	cl /c /EHsc "verylongfilepathnamethatwillmostlikelybegreaterthanonehundredandfourtyfourcharacters.cxx" /DCALC_EXPORTS /DCALC_HEADER="\"calc header/calc.h\"" /I include
+	cl /c /EHsc "verylongfilepathnamethatwilldefinitelybegreaterthanonehundredandfourtyfourcharacters.cxx" /DCALC_EXPORTS /DCALC_HEADER="\"calc header/calc.h\"" /I include
 	cl /c /EHsc main.cxx /I include
-	link $(LFLAGS) verylongfilepathnamethatwillmostlikelybegreaterthanonehundredandfourtyfourcharacters.obj /DLL
-	link $(LFLAGS) main.obj verylongfilepathnamethatwillmostlikelybegreaterthanonehundredandfourtyfourcharacters.lib /out:tester.exe
+	link $(LFLAGS) verylongfilepathnamethatwilldefinitelybegreaterthanonehundredandfourtyfourcharacters.obj /DLL
+	link $(LFLAGS) main.obj verylongfilepathnamethatwilldefinitelybegreaterthanonehundredandfourtyfourcharacters.lib /out:tester.exe
 	tester.exe
 	cd ../../../..
 
@@ -163,12 +163,12 @@ test_relocate_long_paths: test_long_paths
 	cd ..
 	mkdir tmp_bin
 	mkdir tmp_lib
-	move evenlongersubdirectoryname\verylongfilepathnamethatwillmostlikelybegreaterthanonehundredandfourtyfourcharacters.dll tmp_bin\verylongfilepathnamethatwillmostlikelybegreaterthanonehundredandfourtyfourcharacters.dll
-	move evenlongersubdirectoryname\verylongfilepathnamethatwillmostlikelybegreaterthanonehundredandfourtyfourcharacters.lib tmp_lib\verylongfilepathnamethatwillmostlikelybegreaterthanonehundredandfourtyfourcharacters.lib
-	evenlongersubdirectoryname\relocate.exe --pe tmp_bin\verylongfilepathnamethatwillmostlikelybegreaterthanonehundredandfourtyfourcharacters.dll --coff tmp_lib\verylongfilepathnamethatwillmostlikelybegreaterthanonehundredandfourtyfourcharacters.lib --export
+	move evenlongersubdirectoryname\verylongfilepathnamethatwilldefinitelybegreaterthanonehundredandfourtyfourcharacters.dll tmp_bin\verylongfilepathnamethatwilldefinitelybegreaterthanonehundredandfourtyfourcharacters.dll
+	move evenlongersubdirectoryname\verylongfilepathnamethatwilldefinitelybegreaterthanonehundredandfourtyfourcharacters.lib tmp_lib\verylongfilepathnamethatwilldefinitelybegreaterthanonehundredandfourtyfourcharacters.lib
+	evenlongersubdirectoryname\relocate.exe --pe tmp_bin\verylongfilepathnamethatwilldefinitelybegreaterthanonehundredandfourtyfourcharacters.dll --coff tmp_lib\verylongfilepathnamethatwilldefinitelybegreaterthanonehundredandfourtyfourcharacters.lib --export
 	cd evenlongersubdirectoryname
 	del tester.exe
-	link main.obj ..\tmp_lib\verylongfilepathnamethatwillmostlikelybegreaterthanonehundredandfourtyfourcharacters.lib /out:tester.exe
+	link main.obj ..\tmp_lib\verylongfilepathnamethatwilldefinitelybegreaterthanonehundredandfourtyfourcharacters.lib /out:tester.exe
 	.\tester.exe
 	cd ../../../..
 

--- a/Makefile
+++ b/Makefile
@@ -147,12 +147,13 @@ test_long_paths: build_and_check_test_sample
 	xcopy /E "test\src file" tmp\tmp\verylongdirectoryname\evenlongersubdirectoryname
 	xcopy test\main.cxx tmp\tmp\verylongdirectoryname\evenlongersubdirectoryname
 	cd tmp\tmp\verylongdirectoryname\evenlongersubdirectoryname
+	rename calc.cxx verylongfilepathnamethatwillmostlikelybegreaterthanonehundredandfourtyfourcharacters.cxx
 	copy ..\..\..\..\cl.exe cl.exe
 	-@ if NOT EXIST "link.exe" mklink link.exe cl.exe
-	cl /c /EHsc "calc.cxx" /DCALC_EXPORTS /DCALC_HEADER="\"calc header/calc.h\"" /I include
+	cl /c /EHsc "verylongfilepathnamethatwillmostlikelybegreaterthanonehundredandfourtyfourcharacters.cxx" /DCALC_EXPORTS /DCALC_HEADER="\"calc header/calc.h\"" /I include
 	cl /c /EHsc main.cxx /I include
-	link $(LFLAGS) calc.obj /DLL
-	link $(LFLAGS) main.obj calc.lib /out:tester.exe
+	link $(LFLAGS) verylongfilepathnamethatwillmostlikelybegreaterthanonehundredandfourtyfourcharacters.obj /DLL
+	link $(LFLAGS) main.obj verylongfilepathnamethatwillmostlikelybegreaterthanonehundredandfourtyfourcharacters.lib /out:tester.exe
 	tester.exe
 	cd ../../../..
 
@@ -162,19 +163,19 @@ test_relocate_long_paths: test_long_paths
 	cd ..
 	mkdir tmp_bin
 	mkdir tmp_lib
-	move evenlongersubdirectoryname\calc.dll tmp_bin\calc.dll
-	move evenlongersubdirectoryname\calc.lib tmp_lib\calc.lib
-	evenlongersubdirectoryname\relocate.exe --pe tmp_bin\calc.dll --coff tmp_lib\calc.lib --export
+	move evenlongersubdirectoryname\verylongfilepathnamethatwillmostlikelybegreaterthanonehundredandfourtyfourcharacters.dll tmp_bin\verylongfilepathnamethatwillmostlikelybegreaterthanonehundredandfourtyfourcharacters.dll
+	move evenlongersubdirectoryname\verylongfilepathnamethatwillmostlikelybegreaterthanonehundredandfourtyfourcharacters.lib tmp_lib\verylongfilepathnamethatwillmostlikelybegreaterthanonehundredandfourtyfourcharacters.lib
+	evenlongersubdirectoryname\relocate.exe --pe tmp_bin\verylongfilepathnamethatwillmostlikelybegreaterthanonehundredandfourtyfourcharacters.dll --coff tmp_lib\verylongfilepathnamethatwillmostlikelybegreaterthanonehundredandfourtyfourcharacters.lib --export
 	cd evenlongersubdirectoryname
 	del tester.exe
-	link main.obj ..\tmp_lib\calc.lib /out:tester.exe
+	link main.obj ..\tmp_lib\verylongfilepathnamethatwillmostlikelybegreaterthanonehundredandfourtyfourcharacters.lib /out:tester.exe
 	.\tester.exe
 	cd ../../../..
 
 test_and_cleanup: test clean-test
 
 
-test: test_wrapper test_relocate_exe test_relocate_dll test_relocate_long_paths test_pipe_overflow
+test: test_wrapper test_relocate_exe test_relocate_dll test_long_paths test_pipe_overflow
 
 
 clean : clean-test clean-cl

--- a/src/coff_parser.cxx
+++ b/src/coff_parser.cxx
@@ -378,7 +378,8 @@ bool CoffParser::NormalizeName(std::string& name) {
     // The dll is found with and without an extenion, depending on the context of the location
     // i.e. in the section data, it can be found with both an extension and extensionless
     //  whereas in the symbol table or linker member strings, it's always found without an extension
-    std::string const name_no_ext = strip(name, ".dll");
+    std::string const name_no_dll = strip(name, ".dll");
+    std::string const name_no_ext = strip(name_no_dll, ".DLL");
     // Flag allowing us to skip multiple attempts
     // to rename the long names member this name
     bool long_name_renamed = false;

--- a/src/ld.cxx
+++ b/src/ld.cxx
@@ -38,7 +38,7 @@ DWORD LdInvocation::InvokeToolchain() {
         std::string dll_name;
         try {
             dll_name = link_run.get_mangled_out();
-        } catch (const SpackCompilerWrapperError& e) {
+        } catch (const NameTooLongError& e) {
             std::cerr << "Unable to mangle PE " << link_run.get_out()
                       << " name is too long\n";
             return ExitConditions::NORMALIZE_NAME_FAILURE;

--- a/src/ld.cxx
+++ b/src/ld.cxx
@@ -6,6 +6,7 @@
 #include "ld.h"
 #include <minwindef.h>
 #include <cstdio>
+#include <iostream>
 #include "coff_parser.h"
 #include "coff_reader_writer.h"
 #include "linker_invocation.h"
@@ -34,7 +35,14 @@ DWORD LdInvocation::InvokeToolchain() {
     // We're creating a dll, we need to create an appropriate import lib
     if (!link_run.IsExeLink()) {
         std::string const imp_lib_name = link_run.get_implib_name();
-        std::string dll_name = link_run.get_mangled_out();
+        std::string dll_name;
+        try {
+            dll_name = link_run.get_mangled_out();
+        } catch (const SpackCompilerWrapperError& e) {
+            std::cerr << "Unable to mangle PE " << link_run.get_out()
+                      << " name is too long\n";
+            return ExitConditions::NORMALIZE_NAME_FAILURE;
+        }
         std::string const abs_out_imp_lib_name = imp_lib_name + ".dll-abs.lib";
         std::string def = "-def ";
         std::string piped_args = link_run.get_lib_link_args();

--- a/src/linker_invocation.cxx
+++ b/src/linker_invocation.cxx
@@ -50,10 +50,7 @@ void LinkerInvocation::Parse() {
             this->is_exe_ = false;
         } else if (startswith(normal_token, "-out") ||
                    startswith(normal_token, "/out")) {
-            StrList split_out = split(*token, ":", 1);
-            StrList const split_name =
-                StrList(split_out.begin() + 1, split_out.end());
-            this->output_ = join(split_name, "\\");
+            this->output_ = split(*token, ":", 1)[1];
         } else if (endswith(normal_token, ".obj")) {
             this->objs_.push_back(*token);
         } else if (startswith(normal_token, "@") &&

--- a/src/linker_invocation.cxx
+++ b/src/linker_invocation.cxx
@@ -50,7 +50,10 @@ void LinkerInvocation::Parse() {
             this->is_exe_ = false;
         } else if (startswith(normal_token, "-out") ||
                    startswith(normal_token, "/out")) {
-            this->output_ = split(*token, ":")[1];
+            StrList split_out = split(*token, ":", 1);
+            StrList const split_name =
+                StrList(split_out.begin() + 1, split_out.end());
+            this->output_ = join(split_name, "\\");
         } else if (endswith(normal_token, ".obj")) {
             this->objs_.push_back(*token);
         } else if (startswith(normal_token, "@") &&
@@ -67,7 +70,11 @@ void LinkerInvocation::Parse() {
     }
     std::string const ext = this->is_exe_ ? ".exe" : ".dll";
     if (this->output_.empty()) {
-        this->output_ = strip(this->objs_.front(), ".obj") + ext;
+        // with no "out" argument, the linker
+        // will place the file in the CWD
+        std::string const name_obj = this->objs_.front();
+        std::string const filename = split(name_obj, "\\").back();
+        this->output_ = join({GetCWD(), strip(filename, ".obj")}, "\\") + ext;
     }
     this->name_ = strip(this->output_, ext);
     if (this->implibname_.empty()) {

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -98,7 +98,7 @@ int main(int argc, const char* argv[]) {
                 rpath_lib = std::make_unique<LibRename>(patch_args.at("pe"),
                                                         full, deploy, true);
             }
-        } catch (const SpackCompilerWrapperError& e) {
+        } catch (const NameTooLongError& e) {
             std::cerr << "Cannot Rename PE file " << patch_args.at("pe")
                       << " it contains references that are too long.\n";
             return ExitConditions::RENAME_FAILURE;
@@ -121,7 +121,7 @@ int main(int argc, const char* argv[]) {
                 LibRename portable_executable(
                     report_args.at("pe"), std::string(), false, false, true);
                 portable_executable.ExecuteRename();
-            } catch (const SpackCompilerWrapperError& e) {
+            } catch (const NameTooLongError& e) {
                 std::cerr
                     << "Unable to parse command line for reporting\n"
                     << "run command with --help flag for accepted command "

--- a/src/utils.cxx
+++ b/src/utils.cxx
@@ -15,6 +15,7 @@
 #include <winerror.h>
 #include <winnls.h>
 #include <winnt.h>
+#include <winsock.h>
 
 #include <algorithm>
 #include <cctype>
@@ -124,16 +125,25 @@ std::wstring ConvertASCIIToWide(const std::string& str) {
  * Decomposes the input string into a list separated by
  * delim
  * 
+ * Count determines how many delims will be processed
+ * if count > 0
+ * 
  * Returns the list produced by breaking up input string s on delim
  */
-StrList split(const std::string& str, const std::string& delim) {
+StrList split(const std::string& str, const std::string& delim,
+              const u_int count) {
     size_t pos_start = 0;
     size_t pos_end;
     size_t const delim_len = delim.length();
     std::string token;
     StrList res = StrList();
-
-    while ((pos_end = str.find(delim, pos_start)) != std::string::npos) {
+    u_int delim_count = count;
+    if (!count) {
+        delim_count += 1;
+    }
+    u_int delim_found = 0;
+    while (((pos_end = str.find(delim, pos_start)) != std::string::npos) &&
+           delim_found < delim_count) {
         size_t const token_len = pos_end - pos_start;
         token = str.substr(pos_start, token_len);
         pos_start = pos_end + delim_len;
@@ -141,6 +151,9 @@ StrList split(const std::string& str, const std::string& delim) {
             continue;
         }
         res.push_back(token);
+        if (count) {
+            delim_found += 1;
+        }
     }
     res.push_back(str.substr(pos_start));
     return res;

--- a/src/utils.cxx
+++ b/src/utils.cxx
@@ -127,6 +127,7 @@ std::wstring ConvertASCIIToWide(const std::string& str) {
  * 
  * Count determines how many delims will be processed
  * if count > 0
+ * if count == 0, all delimiters are split
  * 
  * Returns the list produced by breaking up input string s on delim
  */
@@ -137,13 +138,10 @@ StrList split(const std::string& str, const std::string& delim,
     size_t const delim_len = delim.length();
     std::string token;
     StrList res = StrList();
-    u_int delim_count = count;
-    if (!count) {
-        delim_count += 1;
-    }
-    u_int delim_found = 0;
+    bool delim_count_reached = false;
+    u_int delim_count = 0;
     while (((pos_end = str.find(delim, pos_start)) != std::string::npos) &&
-           delim_found < delim_count) {
+           !delim_count_reached) {
         size_t const token_len = pos_end - pos_start;
         token = str.substr(pos_start, token_len);
         pos_start = pos_end + delim_len;
@@ -151,8 +149,9 @@ StrList split(const std::string& str, const std::string& delim,
             continue;
         }
         res.push_back(token);
+        ++delim_count;
         if (count) {
-            delim_found += 1;
+            delim_count_reached = count == delim_count;
         }
     }
     res.push_back(str.substr(pos_start));

--- a/src/utils.cxx
+++ b/src/utils.cxx
@@ -589,8 +589,7 @@ std::string short_name_post_prefix(const std::string& path) {
                   << " also too long to relocate.\n";
         std::cerr << "Please move Spack prefix "
                   << " to a shorter directory.\n";
-        throw SpackCompilerWrapperError(
-            "DLL Path too long, cannot be relocated.");
+        throw NameTooLongError("DLL Path too long, cannot be relocated.");
     }
     return new_abs_out;
 }
@@ -806,9 +805,9 @@ char* findstr(char* search_str, const char* substr, size_t size) {
     return nullptr;
 }
 
-SpackCompilerWrapperError::SpackCompilerWrapperError(char const* const message)
+NameTooLongError::NameTooLongError(char const* const message)
     : std::runtime_error(message) {}
 
-char const* SpackCompilerWrapperError::what() const {
+char const* NameTooLongError::what() const {
     return exception::what();
 }

--- a/src/utils.cxx
+++ b/src/utils.cxx
@@ -556,7 +556,10 @@ std::string mangle_name(const std::string& name) {
     if (abs_out.length() > MAX_NAME_LEN) {
         // Name is too long we need to attempt to shorten
         // strip prefix
-        std::string const pre = getenv("SPACK_STAGE_DIR");
+        std::string pre = GetSpackEnv("SPACK_STAGE_DIR");
+        if (pre.empty()) {
+            pre = GetCWD();
+        }
         std::string const rel = R"(\\?\)" + lstrip(abs_out, pre);
         // Get SFN length so we can create buffer
         DWORD const sfn_size = GetShortPathNameA(rel.c_str(), nullptr, 0);

--- a/src/utils.cxx
+++ b/src/utils.cxx
@@ -561,7 +561,7 @@ std::string mangle_name(const std::string& name) {
         std::wstring const wrel = ConvertASCIIToWide(rel);
         wchar_t sfn;
         DWORD const sfn_size =
-            GetShortPathName(wrel.c_str(), &sfn, wrel.length());
+            GetShortPathNameW(wrel.c_str(), &sfn, wrel.length());
         std::wstring const wrel_sfn = std::wstring(sfn, sfn_size);
         std::string const rel_sfn = ConvertWideToASCII(wrel_sfn);
         std::string const new_abs_out = join({pre, rel_sfn}, "\\");

--- a/src/utils.cxx
+++ b/src/utils.cxx
@@ -178,7 +178,7 @@ std::string strip(const std::string& str, const std::string& substr) {
 std::string lstrip(const std::string& str, const std::string& substr) {
     if (!startswith(str, substr))
         return str;
-    return str.substr(substr.size() - 1, str.size());
+    return str.substr(substr.size(), str.size());
 }
 
 /**

--- a/src/utils.cxx
+++ b/src/utils.cxx
@@ -515,17 +515,16 @@ int get_padding_length(const std::string& name) {
     return count;
 }
 
-std::string strip_padding(const std::string &lib)
-{
+std::string strip_padding(const std::string& lib) {
     // One of the padding characters is a legitimate
     // path separator
-    int pad_len = get_padding_length(lib)-1;
+    int const pad_len = get_padding_length(lib) - 1;
     // Capture the drive and drive separator
-    std::string::const_iterator p = lib.cbegin();
-    std::string::const_iterator e = lib.cbegin()+2;
-    std::string stripped_drive(p, e);
+    std::string::const_iterator const p = lib.cbegin();
+    std::string::const_iterator e = lib.cbegin() + 2;
+    std::string const stripped_drive(p, e);
     e = e + pad_len;
-    std::string path_remainder(e, lib.end());
+    std::string const path_remainder(e, lib.end());
     return stripped_drive + path_remainder;
 }
 
@@ -579,7 +578,7 @@ bool SpackInstalledLib(const std::string& lib) {
             "unset");
         return false;
     }
-    std::string stripped_lib = strip_padding(lib);
+    std::string const stripped_lib = strip_padding(lib);
     startswith(stripped_lib, prefix);
 }
 

--- a/src/utils.cxx
+++ b/src/utils.cxx
@@ -566,7 +566,8 @@ std::string getSFN(const std::string& path) {
     char* sfn = new char[sfn_size + 1];
     GetShortPathNameA(escaped.c_str(), sfn, escaped.length());
     // sfn is null terminated per win32 api
-    std::string s_sfn = std::string(sfn);
+    // Ensure we strip out the disable string parsing prefix
+    std::string s_sfn = lstrip(sfn, R"(\\?\)");
     delete[] sfn;
     return s_sfn;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -163,7 +163,7 @@ bool IsPathAbsolute(const std::string& pth);
 
 bool hasPathCharacters(const std::string& name);
 
-std::string short_name_post_prefix(const std::string& path);
+std::string short_name(const std::string& path);
 
 std::string mangle_name(const std::string& name);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -240,9 +240,9 @@ const std::map<char, char> path_to_special_characters{{'\\', '|'},
                                                       {'/', '|'},
                                                       {':', ';'}};
 
-class SpackCompilerWrapperError : public std::runtime_error {
+class NameTooLongError : public std::runtime_error {
    public:
-    SpackCompilerWrapperError(char const* const message);
+    NameTooLongError(char const* const message);
     virtual char const* what() const;
 };
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -22,6 +22,21 @@
 #define _STRING(m) #m
 #define STRING(m) _STRING(m)
 
+/**
+ * This MACRO represents an undocumented
+ * limit to the potential length of a
+ * dll "name" in a COFF/PE file.
+ * Names longer than this can cause the 
+ * librarian tool (lib.exe) to overwrite
+ * sections of the file adjacent to the
+ * name.
+ * The limit appears to be 143 characters
+ * A size of 144 is valid, except in cases
+ * where the name in the PE/COFF file must
+ * be null terminated, so we use 143
+ * to avoid the null terminator causing an
+ * overwrite.
+ */
 #define MAX_NAME_LEN 143
 
 #define MIN_PADDING_THRESHOLD 8

--- a/src/utils.h
+++ b/src/utils.h
@@ -71,7 +71,8 @@ std::wstring ConvertASCIIToWide(const std::string& str);
 // Splits argument "s" by delineator delim
 // Returns vector of strings, if delim is present
 // Returns a single item list
-StrList split(const std::string& s, const std::string& delim);
+StrList split(const std::string& s, const std::string& delim,
+              const u_int count = 0);
 
 //Strips substr off the RHS of the larger string
 std::string strip(const std::string& s, const std::string& substr);

--- a/src/utils.h
+++ b/src/utils.h
@@ -172,7 +172,7 @@ void replace_path_characters(char* path, size_t len);
 
 void replace_special_characters(char* mangled, size_t len);
 
-bool SpackInstalledLib(const std::string &lib);
+bool SpackInstalledLib(const std::string& lib);
 
 // File and File handle helpers //
 
@@ -236,5 +236,11 @@ const std::map<char, char> special_character_to_path{{'|', '\\'}, {';', ':'}};
 const std::map<char, char> path_to_special_characters{{'\\', '|'},
                                                       {'/', '|'},
                                                       {':', ';'}};
+
+class SpackCompilerWrapperError : public std::runtime_error {
+   public:
+    SpackCompilerWrapperError(char const* const message);
+    virtual char const* what() const;
+};
 
 static bool DEBUG = false;

--- a/src/utils.h
+++ b/src/utils.h
@@ -163,6 +163,8 @@ bool IsPathAbsolute(const std::string& pth);
 
 bool hasPathCharacters(const std::string& name);
 
+std::string short_name_post_prefix(const std::string& path);
+
 std::string mangle_name(const std::string& name);
 
 int get_padding_length(const std::string& name);

--- a/src/winrpath.cxx
+++ b/src/winrpath.cxx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: (Apache-2.0 OR MIT)
  */
 #include <cstdio>
-#include <cstdio>
+#include <stdio.h>
 #include <windows.h>  // NOLINT
 #include "winrpath.h"
 #include <fileapi.h>
@@ -92,12 +92,21 @@ bool LibRename::RenameDll(char* name_loc, const std::string& dll_path) const {
             return false;
         }
         LibraryFinder lib_finder;
-        std::string const new_library_loc =
+        std::string new_library_loc =
             lib_finder.FindLibrary(file_name, dll_path);
         if (new_library_loc.empty()) {
             std::cerr << "Unable to find library " << file_name << " from "
                       << dll_path << " for relocation" << "\n";
             return false;
+        }
+        if (new_library_loc.length() > MAX_NAME_LEN) {
+            try {
+                std::string const short_lib_loc =
+                    short_name_post_prefix(new_library_loc);
+                new_library_loc = short_lib_loc;
+            } catch (SpackCompilerWrapperError& e) {
+                return false;
+            }
         }
         char* new_lib_pth =
             pad_path(new_library_loc.c_str(),

--- a/src/winrpath.cxx
+++ b/src/winrpath.cxx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: (Apache-2.0 OR MIT)
  */
 #include <cstdio>
-#include <stdio.h>
+#include <cstdio>
 #include <windows.h>  // NOLINT
 #include "winrpath.h"
 #include <fileapi.h>
@@ -104,7 +104,7 @@ bool LibRename::RenameDll(char* name_loc, const std::string& dll_path) const {
                 std::string const short_lib_loc =
                     short_name_post_prefix(new_library_loc);
                 new_library_loc = short_lib_loc;
-            } catch (SpackCompilerWrapperError& e) {
+            } catch (NameTooLongError& e) {
                 return false;
             }
         }
@@ -421,7 +421,7 @@ bool LibRename::ExecuteLibRename() {
             std::cerr << "Unable to normalize name: " << mangled_name << "\n";
             return false;
         }
-    } catch (const SpackCompilerWrapperError& e) {
+    } catch (const NameTooLongError& e) {
         std::cerr << "Unable to mangle name, DLL name " << this->pe
                   << " too long\n";
         return false;

--- a/src/winrpath.cxx
+++ b/src/winrpath.cxx
@@ -101,9 +101,7 @@ bool LibRename::RenameDll(char* name_loc, const std::string& dll_path) const {
         }
         if (new_library_loc.length() > MAX_NAME_LEN) {
             try {
-                std::string const short_lib_loc =
-                    short_name_post_prefix(new_library_loc);
-                new_library_loc = short_lib_loc;
+                new_library_loc = short_name(new_library_loc);
             } catch (NameTooLongError& e) {
                 return false;
             }


### PR DESCRIPTION
mangle_name previously assumed that the path being passed into pad_path was an appropriate length.
* Add handling for long DLL name paths.
  * Add a check for names longer than 143 characters (DLL name limit in lib/DLL files).
  * Add handling for names that are longer than 143 characters.
  * Use Short FIle Names (SFN or 8.3 file names) to attempt to reduce the name length. SFN are a terse, legal naming scheme for Windows paths. 
 
The shortening strategy is to compute the SFN for the path to a given DLL in import libraries. This allows us maximal path shortening and a better likelihood we'll be able to successfully relocate the DLL path.

If this shortened path is still to long, we stop attempting to do anything and request the user move to a shorter prefix.

Expanded the `split` api to include an optional `count` argument that will stop splitting early if we've split `count` delineators.

Misc bug fixes encountered as I developed are also included.

`lstrip` had incorrect indexing when taking the substring, corrected the indexing (behavior is now tested).
`normalizename` failed to strip capitalized extensions from the name. This handling is still sub-optimal, but I had already started refactoring it in another branch to handle executables as shared libraries (Windows, what a platform), so I'll just update that PR once this lands.
