### PR TITLE
winrpath: Obtain access with scopedfilereader

### DIFF
--- a/src/winrpath.cxx
+++ b/src/winrpath.cxx
@@ -398,7 +398,8 @@ bool LibRename::ExecutePERename() {
         return false;
     }
     try {
-        ScopedFileAccess const obtain_write(pe_path, GENERIC_ALL);
+        ScopedFileAccess obtain_write(pe_path, GENERIC_ALL);
+        obtain_write.Access();
         HANDLE pe_handle = CreateFileW(
             pe_path.c_str(), (GENERIC_READ | GENERIC_WRITE), FILE_SHARE_WRITE,
             nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);


### PR DESCRIPTION
We forgot to call "Access" when we refactored this class away from implicit permission acquisition in the constructor and toward an intentional access acquisition