### PR TITLE
Support install prefixes with spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 #		        is provided to nmake
 #   test    - 
 
-!IFNDEF "$(PREFIX)"
+!IFNDEF PREFIX
 PREFIX="$(MAKEDIR)\install\"
 !ENDIF
 
@@ -64,12 +64,12 @@ cl.exe :  $(SRCS)
 	link $(LFLAGS) $** $(API_LIBS) /out:cl.exe
 
 install : cl.exe
-	mkdir "$(PREFIX)"
-	move cl.exe "$(PREFIX)""
-	mklink "$(PREFIX)\link.exe" "$(PREFIX)\cl.exe"
-	mklink "$(PREFIX)\ifx.exe" "$(PREFIX)\cl.exe"
-	mklink "$(PREFIX)\ifort.exe" "$(PREFIX)\ifort.exe"
-	mklink "$(PREFIX)\relocate.exe" "$(PREFIX)\cl.exe"
+	@if not exist "$(PREFIX)" mkdir "$(PREFIX)""
+	@if not exist "$(PREFIX)\cl.exe" move cl.exe "$(PREFIX)"
+	@if not exist "$(PREFIX)\link.exe" mklink "$(PREFIX)\link.exe" "$(PREFIX)\cl.exe"
+	@if not exist "$(PREFIX)\ifx.exe" mklink "$(PREFIX)\ifx.exe" "$(PREFIX)\cl.exe"
+	@if not exist "$(PREFIX)\ifort.exe" mklink "$(PREFIX)\ifort.exe" "$(PREFIX)\ifort.exe"
+	@if not exist "$(PREFIX)\relocate.exe" mklink "$(PREFIX)\relocate.exe" "$(PREFIX)\cl.exe"
 
 setup_test: cl.exe
 	@echo \n

--- a/Makefile
+++ b/Makefile
@@ -64,12 +64,12 @@ cl.exe :  $(SRCS)
 	link $(LFLAGS) $** $(API_LIBS) /out:cl.exe
 
 install : cl.exe
-	mkdir $(PREFIX)
-	move cl.exe $(PREFIX)
-	mklink $(PREFIX)\link.exe $(PREFIX)\cl.exe
-	mklink $(PREFIX)\ifx.exe $(PREFIX)\cl.exe
-	mklink $(PREFIX)\ifort.exe $(PREFIX)\ifort.exe
-	mklink $(PREFIX)\relocate.exe $(PREFIX)\cl.exe
+	mkdir "$(PREFIX)"
+	move cl.exe "$(PREFIX)""
+	mklink "$(PREFIX)\link.exe" "$(PREFIX)\cl.exe"
+	mklink "$(PREFIX)\ifx.exe" "$(PREFIX)\cl.exe"
+	mklink "$(PREFIX)\ifort.exe" "$(PREFIX)\ifort.exe"
+	mklink "$(PREFIX)\relocate.exe" "$(PREFIX)\cl.exe"
 
 setup_test: cl.exe
 	@echo \n

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ install : cl.exe
 	@if not exist "$(PREFIX)\cl.exe" move cl.exe "$(PREFIX)"
 	@if not exist "$(PREFIX)\link.exe" mklink "$(PREFIX)\link.exe" "$(PREFIX)\cl.exe"
 	@if not exist "$(PREFIX)\ifx.exe" mklink "$(PREFIX)\ifx.exe" "$(PREFIX)\cl.exe"
-	@if not exist "$(PREFIX)\ifort.exe" mklink "$(PREFIX)\ifort.exe" "$(PREFIX)\ifort.exe"
+	@if not exist "$(PREFIX)\ifort.exe" mklink "$(PREFIX)\ifort.exe" "$(PREFIX)\cl.exe"
 	@if not exist "$(PREFIX)\relocate.exe" mklink "$(PREFIX)\relocate.exe" "$(PREFIX)\cl.exe"
 
 setup_test: cl.exe

--- a/src/ld.cxx
+++ b/src/ld.cxx
@@ -228,7 +228,8 @@ std::unique_ptr<RCFileManager> LdInvocation::createRC(LinkerInvocation& link_run
     const std::string rc_file_name = join({rc_tmp_dir, base_rc_file_name}, "\\");
 
     ExecuteCommand rc_executor("rc",
-                               {"/fo" + res_file_name + " " + rc_file_name});
+                               {"/fo\"" + res_file_name + "\"",
+                                "\"" + rc_file_name + "\""});
     std::ofstream rc_out(rc_file_name);
     if (!rc_out) {
         std::cerr << "Error: could not open rc file for creation: "

--- a/src/toolchain.cxx
+++ b/src/toolchain.cxx
@@ -58,7 +58,7 @@ void ToolChainInvocation::ParseCommandArgs(char const* const* cli) {
 }
 
 std::string ToolChainInvocation::ComposeIncludeArg(std::string& include) {
-    return "/external:I " + include;
+    return "/external:I\"" + include + "\"";
 }
 
 std::string ToolChainInvocation::ComposeLibPathArg(std::string& libPath) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -296,7 +296,7 @@ class LibraryFinder {
 
 class PathRelocator {
    private:
-    bool bc_;
+    bool bc_ = true;  // default: build-cache prefix→prefix mode
     std::string new_prefix_;
     std::map<std::string, std::string> old_new_map;
     std::string relocateBC(std::string const& pe);

--- a/src/winrpath.cxx
+++ b/src/winrpath.cxx
@@ -225,7 +225,7 @@ LibRename::LibRename(std::string p_exe, std::string coff, bool full,
  * Produces something like `/EXPORTS <name of coff file>`
  */
 std::string LibRename::ComputeDefLine() {
-    return "/NOLOGO /EXPORTS " + this->coff;
+    return "/NOLOGO /EXPORTS \"" + this->coff + "\"";
 }
 
 /**
@@ -440,10 +440,10 @@ bool LibRename::ExecutePERename() {
  * 
 */
 std::string LibRename::ComputeRenameLink() {
-    std::string line("-def:");
-    line += this->def_file + " ";
-    line += "-name:";
-    line += mangle_name(this->pe) + " ";
+    std::string line("-def:\"");
+    line += this->def_file + "\" ";
+    line += "-name:\"";
+    line += mangle_name(this->pe) + "\" ";
     std::string const name(stem(this->coff));
     if (!this->replace) {
         this->new_lib = name + ".abs-name.lib";


### PR DESCRIPTION
Evidently we missed a few places that choke if there's a space in the install prefix

* Allows for the installation prefix to have spaces by quoting PREFIX usages in the makefile
* Ensures the rename link invocation coff and name references are qouted
* Ensure the dumbin invocation's coff file reference is quoted 

Note: MAKEDIR usage in the makefile is not quoted like PREFIX is as it is only used with `SET` thus far and `SET` does not care about whitespace (in that it allows it and does not break on whitespace), if MAKEDIR is needed with a non `SET` command later, it should be quoted at that time