### PR TITLE
General Wrapper Optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 *.def
 *.res
 *.rc
+*.dmp
 
 # Vscode 
 /.vscode/

--- a/BUILD.md
+++ b/BUILD.md
@@ -7,13 +7,32 @@
 ## Instructions
 
 1. Navigate to the root of the compiler wrapper source (hint, it's the directory this file should be in)
-1. `mkdir .\build && cd build`
-1. nmake /f ..\Makefile
+1. nmake /f Makefile
+
+The inference rule that compiles the sources looks for them in `src` relative to
+the current directory, so run NMAKE from the source root rather than a separate
+build directory.
 
 With the last instruction, one of the targets can optionally be specified:
     * cl.exe
     * install
     Where install will build cl.exe and install it into $(CWD)/install from the makefiles'directory, or whereever PREFIX points to.
+
+## Build configurations
+
+The default build is **optimized**: `/O2 /Ob2 /Oi /GL /DNDEBUG /MT`, linked with
+`/LTCG /OPT:REF /OPT:ICF`. This is not incidental - the wrapper is spawned once
+per compiled source file and once per link for every package Spack builds, so an
+unoptimized wrapper is a tax on every translation unit.
+
+`BUILD_TYPE=debug` (or `DEBUG`) switches to `/Od /Zi /MTd` with `/DEBUG`.
+
+NMAKE does not scan `#include` directives, so the Makefile declares every object
+as depending on every header via `$(SRCS) : $(HEADERS)`. **Add new headers to
+that list.** Without it, changing a struct layout or a function signature in a
+header rebuilds only the like-named `.cxx` and leaves the other objects compiled
+against the old declarations - which links without complaint and corrupts memory
+at runtime.
 
 ## Variables that impact the build
 
@@ -23,3 +42,14 @@ In addition to the various standard NMAKE arguments accepted by default, this pr
     * LINKFLAGS   - specify any linker flags
     * PREFIX      - denotes installation prefix for build artifacts, default is CWD\\install
     * BUILD_TYPE  - (one of debug or release), specifies configuration for build
+
+## Measuring wrapper overhead
+
+`test\bench_wrapper.ps1` reports the wrapper process' own CPU time against the
+wrapped compile's wall time, plus batch wall clock at `-j1` and `-jN` against the
+compiler invoked directly. Run it before and after any change to
+`ExecuteCommand` or the per-invocation path.
+
+```
+powershell -ExecutionPolicy Bypass -File test\bench_wrapper.ps1
+```

--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,28 @@
 PREFIX="$(MAKEDIR)\install\"
 !ENDIF
 
-!IF "$(BUILD_TYPE)" == "DEBUG"
-BUILD_CFLAGS = /Zi -D_CRT_SECURE_NO_WARNINGS
+# This binary is spawned once per compiled source file and once per link of
+# every package Spack builds, so it is built optimized by default. Without an
+# explicit /O switch cl.exe defaults to /Od, which leaves every std::string,
+# std::map and iostream operation as an out-of-line call.
+!IF "$(BUILD_TYPE)" == "DEBUG" || "$(BUILD_TYPE)" == "debug" || "$(BUILD_TYPE)" == "Debug"
+BUILD_CFLAGS = /Od /Zi /MTd
 BUILD_LINK = /DEBUG
+TEST_LINK = /DEBUG
+!ELSE
+BUILD_CFLAGS = /O2 /Ob2 /Oi /GL /DNDEBUG /MT
+BUILD_LINK = /LTCG /OPT:REF /OPT:ICF /INCREMENTAL:NO
+TEST_LINK =
 !ENDIF
 
-BASE_CFLAGS = /EHsc
+BASE_CFLAGS = /EHsc /nologo -D_CRT_SECURE_NO_WARNINGS
 CFLAGS = $(BASE_CFLAGS) $(BUILD_CFLAGS) $(CLFLAGS)
-LFLAGS = $(BUILD_LINK) $(LINKFLAGS)
+# Link flags for the wrapper binary itself
+WRAPPER_LFLAGS = $(BUILD_LINK) $(LINKFLAGS)
+# Link flags the test targets hand to the *wrapped* linker. Deliberately free
+# of the wrapper's own codegen options (/LTCG and friends), which describe how
+# this binary is built and have no bearing on the test artifacts it produces.
+LFLAGS = $(TEST_LINK) $(LINKFLAGS)
 # shlwapi: needed for basic path operations
 # pathcch: needed for long path canonicalization
 # advapi32: needed for win32 ACL interactions
@@ -51,6 +65,30 @@ coff_reader_writer.obj \
 coff_parser.obj \
 linker_invocation.obj
 
+HEADERS = src\cl.h \
+src\coff.h \
+src\coff_parser.h \
+src\coff_pe_reporter.h \
+src\coff_reader_writer.h \
+src\commandline.h \
+src\execute.h \
+src\intel.h \
+src\ld.h \
+src\linker_invocation.h \
+src\regex_utils.h \
+src\spack_env.h \
+src\toolchain.h \
+src\toolchain_factory.h \
+src\utils.h \
+src\version.h \
+src\winrpath.h
+
+# NMAKE does not scan #include directives, so every object is declared to
+# depend on every header. Without this, changing a struct layout or a function
+# signature in a header rebuilds only the .cxx that shares its name and leaves
+# the rest of the objects compiled against the old declarations. That links
+# without complaint and corrupts memory at runtime.
+$(SRCS) : $(HEADERS)
 
 {src}.cxx{}.obj::
 	"$(CC)" /c $(CFLAGS) $(CVARS) /I:src $<	
@@ -61,11 +99,16 @@ linker_invocation.obj
 all : install test
 
 cl.exe :  $(SRCS)
-	link $(LFLAGS) $** $(API_LIBS) /out:cl.exe
+	link $(WRAPPER_LFLAGS) $** $(API_LIBS) /out:cl.exe
 
 install : cl.exe
 	@if not exist "$(PREFIX)" mkdir "$(PREFIX)"
-	@if not exist "$(PREFIX)\cl.exe" move cl.exe "$(PREFIX)"
+# Always overwrite. This used to be guarded by "if not exist", which meant a
+# rebuild installed nothing over an existing prefix and callers kept running
+# the previous binary with no indication anything had been skipped.
+	move /Y cl.exe "$(PREFIX)"
+# The symlinks below only need creating once; they resolve by name, so they
+# stay correct across reinstalls of cl.exe
 	@if not exist "$(PREFIX)\link.exe" mklink "$(PREFIX)\link.exe" "$(PREFIX)\cl.exe"
 	@if not exist "$(PREFIX)\ifx.exe" mklink "$(PREFIX)\ifx.exe" "$(PREFIX)\cl.exe"
 	@if not exist "$(PREFIX)\ifort.exe" mklink "$(PREFIX)\ifort.exe" "$(PREFIX)\cl.exe"
@@ -172,7 +215,7 @@ test_pipe_error_overflow: build_and_check_test_sample
 	set SPACK_CC=%SPACK_CC_TMP%
 
 build_zerowrite_test: test\writezero.obj
-	link $(LFLAGS) $** $(API_LIBS) /out:writezero.exe
+	link $(WRAPPER_LFLAGS) $** $(API_LIBS) /out:writezero.exe
 
 test_zerowrite: build_zerowrite_test
 	@echo \n

--- a/src/execute.cxx
+++ b/src/execute.cxx
@@ -186,8 +186,7 @@ std::string ExecuteCommand::ComposeCLI() const {
     // CreateProcessW is called without an lpApplicationName, so the command
     // line itself has to identify the executable. An unquoted path containing
     // spaces makes Windows probe each prefix in turn (C:\Program.exe, ...)
-    // before finding the real tool - a filesystem probe per invocation, and a
-    // hijack opportunity for whoever can drop a file at one of those prefixes.
+    // before finding the real tool - a filesystem probe per invocation
     bool const needs_quoting =
         this->base_command.find_first_of(" \t") != std::string::npos &&
         this->base_command.front() != '\"';

--- a/src/execute.cxx
+++ b/src/execute.cxx
@@ -10,63 +10,70 @@
 #include <handleapi.h>
 #include <minwinbase.h>
 #include <minwindef.h>
-#include <namedpipeapi.h>
 #include <processenv.h>
 #include <processthreadsapi.h>
+#include <synchapi.h>
 #include <winbase.h>
 #include <windows.h>  // NOLINT
 #include <winnt.h>
 
 #include <cstdint>
 #include <cstdlib>
-#include <future>
 #include <iostream>
 #include <stdexcept>
 #include <string>
+#include <system_error>
 #include <utility>
+#include <vector>
 #include "utils.h"
 
 enum : std::uint16_t { InvalidExitCode = 999 };
 
-ExecuteCommand::ExecuteCommand(std::string command)
-    : ChildStdOut_Rd(nullptr),
-      ChildStdOut_Wd(nullptr),
-      ChildStdErr_Rd(nullptr),
-      ChildStdErr_Wd(nullptr),
-      base_command(std::move(command)) {
-    this->CreateChildPipes();
-    this->SetupExecute();
+namespace {
+
+/**
+ * Produces an inheritable duplicate of one of this process' standard handles
+ * so the child can be pointed at it via STARTUPINFOW.
+ *
+ * A missing source handle (a process started without a console and without
+ * redirection) is not an error; the child simply gets no such handle.
+ */
+bool DuplicateInheritable(HANDLE source, HANDLE* out) {
+    *out = INVALID_HANDLE_VALUE;
+    if (source == nullptr || source == INVALID_HANDLE_VALUE) {
+        return true;
+    }
+    HANDLE const self = GetCurrentProcess();
+    return DuplicateHandle(self, source, self, out, 0, TRUE,
+                           DUPLICATE_SAME_ACCESS) != 0;
 }
 
+}  // namespace
+
+ExecuteCommand::ExecuteCommand(std::string command)
+    : base_command(std::move(command)) {}
+
 ExecuteCommand::ExecuteCommand(std::string arg, const StrList& args)
-    : ChildStdOut_Rd(nullptr),
-      ChildStdOut_Wd(nullptr),
-      ChildStdErr_Rd(nullptr),
-      ChildStdErr_Wd(nullptr),
-      base_command(std::move(arg)) {
-    for (const auto& argp : args) {
-        this->command_args.push_back(argp);
-    }
-    this->CreateChildPipes();
-    this->SetupExecute();
-}
+    : base_command(std::move(arg)), command_args(args) {}
 
 ExecuteCommand& ExecuteCommand::operator=(
     ExecuteCommand&& execute_command) noexcept {
-    this->ChildStdOut_Rd = std::move(execute_command.ChildStdOut_Rd);
-    this->ChildStdOut_Wd = std::move(execute_command.ChildStdOut_Wd);
-    this->ChildStdErr_Rd = std::move(execute_command.ChildStdErr_Rd);
-    this->ChildStdErr_Wd = std::move(execute_command.ChildStdErr_Wd);
-    this->procInfo = std::move(execute_command.procInfo);
-    this->startInfo = std::move(execute_command.startInfo);
-    this->saAttr = std::move(execute_command.saAttr);
-    this->fileout = std::move(execute_command.fileout);
-    this->write_to_file = std::move(execute_command.write_to_file);
+    if (this == &execute_command) {
+        return *this;
+    }
+    this->CleanupHandles();
+    this->procInfo = execute_command.procInfo;
+    this->startInfo = execute_command.startInfo;
+    this->fileout = execute_command.fileout;
+    this->write_to_file = execute_command.write_to_file;
+    this->cpw_initalization_failure = execute_command.cpw_initalization_failure;
     this->base_command = std::move(execute_command.base_command);
     this->command_args = std::move(execute_command.command_args);
-    this->child_out_future = std::move(execute_command.child_out_future);
-    this->child_err_future = std::move(execute_command.child_err_future);
-    this->exit_code_future = std::move(exit_code_future);
+    // Hand ownership over completely - the source must not close the handles
+    // we just took when it is destroyed
+    ZeroMemory(&execute_command.procInfo, sizeof(PROCESS_INFORMATION));
+    execute_command.fileout = INVALID_HANDLE_VALUE;
+    execute_command.write_to_file = false;
     return *this;
 }
 
@@ -74,65 +81,21 @@ ExecuteCommand::~ExecuteCommand() {
     this->CleanupHandles();
 }
 
-void ExecuteCommand::SetupExecute() {
-    PROCESS_INFORMATION pi_proc_info;
-    STARTUPINFOW si_start_info;
-    ZeroMemory(&pi_proc_info, sizeof(PROCESS_INFORMATION));
-
-    // Set up members of the STARTUPINFO structure.
-    // This structure specifies the STDIN and STDOUT handles for redirection.
-    ZeroMemory(&si_start_info, sizeof(STARTUPINFOW));
-    si_start_info.cb = sizeof(STARTUPINFOW);
-    // Do not attach the pipe handles here. We'll create inheritable
-    // duplicates of the write ends immediately before CreateProcess to
-    // minimize the inheritance window.
-    si_start_info.hStdError = INVALID_HANDLE_VALUE;
-    si_start_info.hStdOutput = INVALID_HANDLE_VALUE;
-    si_start_info.dwFlags = 0;
-    this->procInfo = pi_proc_info;
-    this->startInfo = si_start_info;
-}
-
-/*
- * Create pipes and handles to communicate with
- * child process
- */
-int ExecuteCommand::CreateChildPipes() {
-    // Create stdout pipes
-    SECURITY_ATTRIBUTES sa_attr;
-    // Create non-inheritable pipes. We'll duplicate the write ends to
-    // inheritable handles immediately before CreateProcess to reduce the
-    // window where other processes could inherit them.
-    sa_attr.nLength = sizeof(SECURITY_ATTRIBUTES);
-    sa_attr.bInheritHandle = FALSE;
-    sa_attr.lpSecurityDescriptor = nullptr;
-    this->saAttr = sa_attr;
-    if (!CreatePipe(&this->ChildStdOut_Rd, &this->ChildStdOut_Wd, &sa_attr, 0))
-        return 0;
-
-    // create stderr pipes
-    SECURITY_ATTRIBUTES sa_attr_err;
-    sa_attr_err.nLength = sizeof(SECURITY_ATTRIBUTES);
-    sa_attr_err.bInheritHandle = FALSE;
-    sa_attr_err.lpSecurityDescriptor = nullptr;
-    this->saAttrErr = sa_attr_err;
-    if (!CreatePipe(&this->ChildStdErr_Rd, &this->ChildStdErr_Wd, &sa_attr_err,
-                    0))
-        return 0;
-
-    return 1;
-}
-
 /*
  * Kick off subprocess executing a given toolchain, returns a value indicating
  * whether the subprocess was created successfully
+ *
+ * The child is handed inheritable duplicates of our own standard handles, so
+ * its output lands wherever ours does with no copying by this process. When
+ * this instance was configured to write to a file, that file takes the place
+ * of both stdout and stderr.
  */
 bool ExecuteCommand::ExecuteToolChainChild() {
-    LPVOID lp_msg_buf;
+    const std::string cli = this->ComposeCLI();
+    DEBUG_LOG("Executing Command: " + cli);
     std::wstring c_command_line;
-    debug("Executing Command: " + this->ComposeCLI());
     try {
-        c_command_line = ConvertASCIIToWide(this->ComposeCLI());
+        c_command_line = ConvertASCIIToWide(cli);
     } catch (const std::overflow_error& e) {
         std::cerr << e.what() << "\n";
         return false;
@@ -140,151 +103,62 @@ bool ExecuteCommand::ExecuteToolChainChild() {
     // Duplicate command line into writable buffer expected by CreateProcessW
     std::vector<wchar_t> cmdbuf(c_command_line.begin(), c_command_line.end());
     cmdbuf.push_back(L'\0');
-    wchar_t* nc_command_line = cmdbuf.data();
-    // Duplicate our non-inheritable write handles into inheritable handles
-    // immediately before CreateProcess to minimize the inheritance window.
-    HANDLE inheritableOut = INVALID_HANDLE_VALUE;
-    HANDLE inheritableErr = INVALID_HANDLE_VALUE;
-    HANDLE const self = GetCurrentProcess();
-    if (this->ChildStdOut_Wd && this->ChildStdOut_Wd != INVALID_HANDLE_VALUE) {
-        if (!DuplicateHandle(self, this->ChildStdOut_Wd, self, &inheritableOut,
-                             0, TRUE, DUPLICATE_SAME_ACCESS)) {
-            return false;
-        }
-        this->startInfo.hStdOutput = inheritableOut;
-        this->startInfo.dwFlags |= STARTF_USESTDHANDLES;
-    }
-    if (this->ChildStdErr_Wd && this->ChildStdErr_Wd != INVALID_HANDLE_VALUE) {
-        if (!DuplicateHandle(self, this->ChildStdErr_Wd, self, &inheritableErr,
-                             0, TRUE, DUPLICATE_SAME_ACCESS)) {
-            // Clean up any previously duplicated handle
-            if (inheritableOut && inheritableOut != INVALID_HANDLE_VALUE)
-                CloseHandle(inheritableOut);
-            return false;
-        }
-        this->startInfo.hStdError = inheritableErr;
-        this->startInfo.dwFlags |= STARTF_USESTDHANDLES;
-    }
 
-    if (!CreateProcessW(nullptr, nc_command_line, nullptr, nullptr, TRUE,
-                        CREATE_UNICODE_ENVIRONMENT, nullptr, nullptr,
-                        &this->startInfo, &this->procInfo)) {
-        // Handle errors coming from creation of child proc
-        FormatMessage(
-            FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
-                FORMAT_MESSAGE_IGNORE_INSERTS,
-            nullptr, GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-            reinterpret_cast<LPTSTR>(&lp_msg_buf), 0, nullptr);
+    HANDLE const out_source = this->write_to_file
+                                  ? this->fileout
+                                  : GetStdHandle(STD_OUTPUT_HANDLE);
+    HANDLE const err_source =
+        this->write_to_file ? this->fileout : GetStdHandle(STD_ERROR_HANDLE);
 
-        try {
-            std::cerr << "Failed to initiate child process from: "
-                      << ConvertWideToASCII(nc_command_line) << " ";
-        } catch (const std::overflow_error& e) {
-            std::cerr << "While handling the exception below another exception "
-                         "occured\n";
-            std::cerr << e.what() << "\n";
-            std::cerr << "Previous exception was:\n";
-        }
-
-        std::cerr << "With error: ";
-        if (lp_msg_buf) {
-            std::cerr << static_cast<char*>(lp_msg_buf) << "\n";
-            LocalFree(lp_msg_buf);
-        } else {
-            std::cerr << reportLastError() << "\n";
-        }
+    HANDLE inheritable_out = INVALID_HANDLE_VALUE;
+    HANDLE inheritable_err = INVALID_HANDLE_VALUE;
+    HANDLE inheritable_in = INVALID_HANDLE_VALUE;
+    if (!DuplicateInheritable(out_source, &inheritable_out) ||
+        !DuplicateInheritable(err_source, &inheritable_err) ||
+        !DuplicateInheritable(GetStdHandle(STD_INPUT_HANDLE),
+                              &inheritable_in)) {
+        // Capture before anything else can overwrite the thread's last error
+        const std::string dup_error = reportLastError();
+        std::cerr << "Unable to prepare standard handles for child process: "
+                  << dup_error << "\n";
+        SafeHandleCleanup(inheritable_out);
+        SafeHandleCleanup(inheritable_err);
+        SafeHandleCleanup(inheritable_in);
         this->cpw_initalization_failure = true;
         return false;
     }
-    // We've suceeded in kicking off the toolchain run
-    // Parent no longer needs the inheritable duplicates; close them in the
-    // parent. The child has inherited its own copies.
-    if (this->startInfo.hStdOutput && this->startInfo.hStdOutput != INVALID_HANDLE_VALUE) {
-        CloseHandle(this->startInfo.hStdOutput);
-        this->startInfo.hStdOutput = INVALID_HANDLE_VALUE;
-    }
-    if (this->startInfo.hStdError && this->startInfo.hStdError != INVALID_HANDLE_VALUE) {
-        CloseHandle(this->startInfo.hStdError);
-        this->startInfo.hStdError = INVALID_HANDLE_VALUE;
-    }
-    // Also ensure our member copies of the write handles are closed in the
-    // parent; they reference the same kernel objects as the STARTUPINFO
-    // entries above.
-    if (this->ChildStdOut_Wd && this->ChildStdOut_Wd != INVALID_HANDLE_VALUE) {
-        SafeHandleCleanup(this->ChildStdOut_Wd);
-        this->ChildStdOut_Wd = INVALID_HANDLE_VALUE;
-    }
-    if (this->ChildStdErr_Wd && this->ChildStdErr_Wd != INVALID_HANDLE_VALUE) {
-        SafeHandleCleanup(this->ChildStdErr_Wd);
-        this->ChildStdErr_Wd = INVALID_HANDLE_VALUE;
+
+    this->startInfo.cb = sizeof(STARTUPINFOW);
+    this->startInfo.dwFlags = STARTF_USESTDHANDLES;
+    this->startInfo.hStdOutput = inheritable_out;
+    this->startInfo.hStdError = inheritable_err;
+    this->startInfo.hStdInput = inheritable_in;
+
+    BOOL const created =
+        CreateProcessW(nullptr, cmdbuf.data(), nullptr, nullptr, TRUE,
+                       CREATE_UNICODE_ENVIRONMENT, nullptr, nullptr,
+                       &this->startInfo, &this->procInfo);
+    // Capture this before the handle cleanup below overwrites it
+    DWORD const spawn_error = created ? 0 : ::GetLastError();
+
+    // The child has its own copies now; ours are dead weight either way
+    SafeHandleCleanup(inheritable_out);
+    SafeHandleCleanup(inheritable_err);
+    SafeHandleCleanup(inheritable_in);
+    this->startInfo.hStdOutput = INVALID_HANDLE_VALUE;
+    this->startInfo.hStdError = INVALID_HANDLE_VALUE;
+    this->startInfo.hStdInput = INVALID_HANDLE_VALUE;
+
+    if (!created) {
+        std::cerr << "Failed to initiate child process from: " << cli
+                  << " With error: "
+                  << std::system_category().message(
+                         static_cast<int>(spawn_error))
+                  << "\n";
+        this->cpw_initalization_failure = true;
+        return false;
     }
     return true;
-}
-
-/* 
- * Reads for the member variable holding a pipe to the wrapped processes'
- * STD_HANDLE (stdour or stderr) and writes either to this processes'
- * STD_HANDLE or a file, depending on how the process wrapper is configured
- */
-int ExecuteCommand::PipeChildToStdStream(DWORD STD_HANDLE,
-                                         HANDLE reader_handle) {
-    DWORD dw_read;
-    DWORD dw_written;
-    std::vector<char> ch_buf(BUFSIZE);
-    BOOL b_success = TRUE;
-    HANDLE h_parent_out;
-    if (this->write_to_file && this->fileout != INVALID_HANDLE_VALUE) {
-        h_parent_out = this->fileout;
-    } else {
-        h_parent_out = GetStdHandle(STD_HANDLE);
-    }
-
-    for (;;) {
-        b_success = ReadFile(reader_handle, ch_buf.data(), BUFSIZE, &dw_read, nullptr);
-        if (!b_success || (dw_read == 0 && this->terminated))
-            break;
-        if (dw_read != 0) {
-            b_success =
-                WriteFile(h_parent_out, ch_buf.data(), dw_read, &dw_written, nullptr);
-            if (dw_written < dw_read && b_success) {
-                // incomplete write but not a failure
-                // since bSuccess is true
-                // So lets write until bSuccess is false or
-                // until all bytes are written
-                DWORD current_pos = dw_written;
-                DWORD remaining = dw_read - dw_written;
-                while (remaining > 0) {
-                    DWORD to_write = remaining;
-                    b_success = WriteFile(h_parent_out, ch_buf.data() + current_pos,
-                                          to_write, &dw_written, nullptr);
-                    if (!b_success)
-                        break;
-                    current_pos += dw_written;
-                    remaining -= dw_written;
-                }
-            }
-            if (!b_success) {
-                break;
-            }
-        }
-        if (!b_success)
-            break;
-    }
-    // Close the reader handle now that we're done reading from the pipe to
-    // release underlying kernel resources. This prevents leaking handles
-    // across many invocations which can cause pipes to never reach EOF and
-    // eventually exhaust kernel resources.
-    if (reader_handle && reader_handle != INVALID_HANDLE_VALUE) {
-        CloseHandle(reader_handle);
-        // Clear the member copy so CleanupHandles doesn't attempt to close the
-        // same handle again.
-        if (reader_handle == this->ChildStdOut_Rd) {
-            this->ChildStdOut_Rd = INVALID_HANDLE_VALUE;
-        } else if (reader_handle == this->ChildStdErr_Rd) {
-            this->ChildStdErr_Rd = INVALID_HANDLE_VALUE;
-        }
-    }
-    return static_cast<int>(static_cast<int>(b_success) == 0);
 }
 
 /*
@@ -292,94 +166,81 @@ int ExecuteCommand::PipeChildToStdStream(DWORD STD_HANDLE,
  * cleaned
  */
 int ExecuteCommand::CleanupHandles() {
-    if (!this->cpw_initalization_failure) {
-        if (this->fileout != INVALID_HANDLE_VALUE)
-            if (!SafeHandleCleanup(this->fileout))
-                return 0;
-        if (!SafeHandleCleanup(this->procInfo.hProcess))
-            return 0;
-        if (!SafeHandleCleanup(this->procInfo.hThread))
-            return 0;
-        return 1;
-    }
-    return 0;
+    int result = 1;
+    if (!SafeHandleCleanup(this->fileout))
+        result = 0;
+    if (!SafeHandleCleanup(this->procInfo.hProcess))
+        result = 0;
+    if (!SafeHandleCleanup(this->procInfo.hThread))
+        result = 0;
+    return result;
 }
 
-/**
- * Reports the exit code of a given process, used as a callback to report
- * on the status of wrapped process which is performed asynchronously
- */
-DWORD ExecuteCommand::ReportExitCode() {
-    DWORD exit_code;
-    while (GetExitCodeProcess(this->procInfo.hProcess, &exit_code)) {
-        if (exit_code != STILL_ACTIVE)
-            break;
-    }
-    this->terminated = true;
-    // Use SafeHandleCleanup to close the process handle and mark it invalid
-    // so later cleanup paths do not attempt to close it again.
-    SafeHandleCleanup(this->procInfo.hProcess);
-    return exit_code;
-}
-
-std::string ExecuteCommand::ComposeCLI() {
-    std::string cli;
-    cli += this->base_command + " ";
+std::string ExecuteCommand::ComposeCLI() const {
+    size_t reserved = this->base_command.size() + 3;
     for (const auto& arg : this->command_args) {
-        cli += arg + " ";
+        reserved += arg.size() + 1;
+    }
+    std::string cli;
+    cli.reserve(reserved);
+    // CreateProcessW is called without an lpApplicationName, so the command
+    // line itself has to identify the executable. An unquoted path containing
+    // spaces makes Windows probe each prefix in turn (C:\Program.exe, ...)
+    // before finding the real tool - a filesystem probe per invocation, and a
+    // hijack opportunity for whoever can drop a file at one of those prefixes.
+    bool const needs_quoting =
+        this->base_command.find_first_of(" \t") != std::string::npos &&
+        this->base_command.front() != '\"';
+    if (needs_quoting) {
+        cli += '\"';
+        cli += this->base_command;
+        cli += '\"';
+    } else {
+        cli += this->base_command;
+    }
+    cli += ' ';
+    for (const auto& arg : this->command_args) {
+        cli += arg;
+        cli += ' ';
     }
     return cli;
 }
 
 /*
- * Execute the wrapped command in subprocess, creating the process, and
- * allowing it, and the piping of its stdout to this process to run asychronously
- * and storing the futures of each async operation to be waited on at a later point
+ * Execute the wrapped command in a subprocess
  *
- * If this instance has been configured to write to a file instead of stdout, opens that file
- * and prepares it for writing
+ * If this instance has been configured to write to a file instead of stdout,
+ * opens that file and hands it to the child as its stdout and stderr
  *
- * Returns a value indicating whether or not the subprocess has been created sucessfully
-*/
+ * Returns a value indicating whether or not the subprocess has been created
+ * successfully
+ */
 bool ExecuteCommand::Execute(const std::string& filename) {
     if (!filename.empty()) {
         this->write_to_file = true;
+        // The child needs to inherit this handle, so it is created
+        // inheritable rather than being duplicated later
+        SECURITY_ATTRIBUTES sa_attr;
+        sa_attr.nLength = sizeof(SECURITY_ATTRIBUTES);
+        sa_attr.bInheritHandle = TRUE;
+        sa_attr.lpSecurityDescriptor = nullptr;
         try {
             this->fileout = CreateFileW(
                 ConvertASCIIToWide(filename).c_str(), FILE_APPEND_DATA,
-                FILE_SHARE_WRITE | FILE_SHARE_READ, &this->saAttr, OPEN_ALWAYS,
+                FILE_SHARE_WRITE | FILE_SHARE_READ, &sa_attr, OPEN_ALWAYS,
                 FILE_ATTRIBUTE_NORMAL, nullptr);
-            if (this->fileout != INVALID_HANDLE_VALUE) {
-                // Ensure file handle is not inheritable by child processes
-                SetHandleInformation(this->fileout, HANDLE_FLAG_INHERIT, 0);
-            }
         } catch (const std::overflow_error& e) {
             std::cerr << e.what() << "\n";
             return false;
         }
+        if (this->fileout == INVALID_HANDLE_VALUE) {
+            const std::string open_error = reportLastError();
+            std::cerr << "Unable to open " << filename
+                      << " to capture command output: " << open_error << "\n";
+            return false;
+        }
     }
-    // Start reader threads before spawning the child so they are ready to
-    // drain the pipe as soon as the child writes. This reduces a small race
-    // window where a very fast child can fill the pipe buffer before the
-    // parent starts reading.
-    this->child_out_future = std::async(
-        std::launch::async, &ExecuteCommand::PipeChildToStdStream, this,
-        STD_OUTPUT_HANDLE, this->ChildStdOut_Rd);
-    this->child_err_future = std::async(
-        std::launch::async, &ExecuteCommand::PipeChildToStdStream, this,
-        STD_ERROR_HANDLE, this->ChildStdErr_Rd);
-
-    bool const ret_code = this->ExecuteToolChainChild();
-    if (ret_code) {
-        // Start exit code watcher only after the process is created
-        this->exit_code_future = std::async(
-            std::launch::async, &ExecuteCommand::ReportExitCode, this);
-    } else {
-        // If we failed to spawn, ensure reader futures are cancelled/observed
-        // by setting terminated so readers can exit promptly.
-        this->terminated = true;
-    }
-    return ret_code;
+    return this->ExecuteToolChainChild();
 }
 
 /*
@@ -387,16 +248,27 @@ bool ExecuteCommand::Execute(const std::string& filename) {
  * and reports exit code of the process
  */
 DWORD ExecuteCommand::Join() {
-    // Join primary thread first
-    // This process sets the termianted flag
-    // without which the reader threads will not
-    // terminate, so the primary thread must be
-    // joined first so we have a guaruntee that the
-    // reader processes can exit
-    const DWORD command_error = this->exit_code_future.get();
-    if (!this->child_out_future.get())
+    if (this->procInfo.hProcess == nullptr ||
+        this->procInfo.hProcess == INVALID_HANDLE_VALUE) {
+        // Nothing was spawned (or this has already been joined); the spawn
+        // failure has already been reported by ExecuteToolChainChild
         return InvalidExitCode;
-    if (!this->child_err_future.get())
+    }
+    if (WaitForSingleObject(this->procInfo.hProcess, INFINITE) !=
+        WAIT_OBJECT_0) {
+        const std::string wait_error = reportLastError();
+        std::cerr << "Failed waiting on child process: " << wait_error << "\n";
         return InvalidExitCode;
-    return command_error;
+    }
+    DWORD exit_code = InvalidExitCode;
+    if (!GetExitCodeProcess(this->procInfo.hProcess, &exit_code)) {
+        const std::string code_error = reportLastError();
+        std::cerr << "Unable to retrieve child process exit code: "
+                  << code_error << "\n";
+        return InvalidExitCode;
+    }
+    // Release the process, and any captured output file, now that the child is
+    // gone - callers rename and delete those files immediately after joining
+    this->CleanupHandles();
+    return exit_code;
 }

--- a/src/execute.h
+++ b/src/execute.h
@@ -9,26 +9,45 @@
 #include <strsafe.h>
 #include <tchar.h>
 #include <windows.h>
-#include <future>
-#include <iostream>
 #include <string>
 #include <vector>
 
 #include "utils.h"
 
-#define BUFSIZE 4096
-
 const std::string empty = std::string();
 
 /**
- * @brief
+ * @brief Spawns a wrapped toolchain process and reports its exit code
+ *
+ * The wrapper is invoked once per compiled source file, so this class does as
+ * little as possible per invocation: the child inherits this process' standard
+ * handles directly rather than having its output pumped through a pipe, and
+ * the parent blocks on the child rather than polling it.
+ *
+ * When Execute() is given a filename, the child's stdout and stderr are
+ * pointed at that file instead. That is used by the relocation path to capture
+ * dumpbin's export listing; nothing on the compile or link path needs it.
+ *
+ * Two invariants here are load-bearing for build throughput:
+ *
+ *  - Wait on the child, never poll it. Join() uses WaitForSingleObject. This
+ *    previously spun on GetExitCodeProcess, which burned a full core per
+ *    in-flight wrapper. That is free at -j1 and catastrophic at -jN: measured
+ *    over 100 compiles at -j20, it cost 98% - the build took almost exactly
+ *    twice as long through the wrapper as without it.
+ *
+ *  - Do not reintroduce per-invocation threads or output relaying. The wrapper
+ *    never inspects the tool's output, so pumping it costs two pipes, three
+ *    threads and a copy of every byte to accomplish nothing.
  */
 class ExecuteCommand {
    public:
     // constructor for single executable/arguments + command in one string
-    ExecuteCommand(std::string command);
+    explicit ExecuteCommand(std::string command);
     ExecuteCommand(std::string arg, const StrList& args);
     ExecuteCommand() = default;
+    ExecuteCommand(const ExecuteCommand&) = delete;
+    ExecuteCommand& operator=(const ExecuteCommand&) = delete;
     ExecuteCommand& operator=(ExecuteCommand&& execute_command) noexcept;
     ~ExecuteCommand();
     bool Execute(const std::string& filename = empty);
@@ -36,34 +55,16 @@ class ExecuteCommand {
     int CleanupHandles();
 
    private:
-    void SetupExecute();
     bool ExecuteToolChainChild();
-    int PipeChildToStdStream(DWORD STD_HANDLE, HANDLE reader_handle);
-    int CreateChildPipes();
-    DWORD ReportExitCode();
-    // Holds the exit code of the
-    // pipe from child process stdout
-    // to parent std out or file
-    std::future<int> child_out_future;
-    // Holds the exit code of the pipe
-    // from child to parent stderr
-    std::future<int> child_err_future;
-    // Holds the exit code of the
-    // command wrapped by this class
-    std::future<DWORD> exit_code_future;
-    std::string ComposeCLI();
-    HANDLE ChildStdOut_Rd;
-    HANDLE ChildStdOut_Wd;
-    HANDLE ChildStdErr_Rd;
-    HANDLE ChildStdErr_Wd;
-    PROCESS_INFORMATION procInfo;
-    STARTUPINFOW startInfo;
-    SECURITY_ATTRIBUTES saAttr;
-    SECURITY_ATTRIBUTES saAttrErr;
+    std::string ComposeCLI() const;
+
+    PROCESS_INFORMATION procInfo{};
+    STARTUPINFOW startInfo{};
+    // Destination for the child's stdout/stderr when Execute() was given a
+    // filename; INVALID_HANDLE_VALUE means "inherit ours"
     HANDLE fileout = INVALID_HANDLE_VALUE;
     bool write_to_file = false;
     bool cpw_initalization_failure = false;
-    bool terminated = false;
     std::string base_command;
     StrList command_args;
 };

--- a/src/execute.h
+++ b/src/execute.h
@@ -28,18 +28,7 @@ const std::string empty = std::string();
  * pointed at that file instead. That is used by the relocation path to capture
  * dumpbin's export listing; nothing on the compile or link path needs it.
  *
- * Two invariants here are load-bearing for build throughput:
- *
- *  - Wait on the child, never poll it. Join() uses WaitForSingleObject. This
- *    previously spun on GetExitCodeProcess, which burned a full core per
- *    in-flight wrapper. That is free at -j1 and catastrophic at -jN: measured
- *    over 100 compiles at -j20, it cost 98% - the build took almost exactly
- *    twice as long through the wrapper as without it.
- *
- *  - Do not reintroduce per-invocation threads or output relaying. The wrapper
- *    never inspects the tool's output, so pumping it costs two pipes, three
- *    threads and a copy of every byte to accomplish nothing.
- */
+ * */
 class ExecuteCommand {
    public:
     // constructor for single executable/arguments + command in one string

--- a/src/ld.cxx
+++ b/src/ld.cxx
@@ -58,7 +58,7 @@ DWORD LdInvocation::InvokeToolchain() {
             std::cerr << "Spack compiler wrapper: no file inputs "
                          "recognized on link line; outputs will not be "
                          "relocatable\n";
-            debug("Unrecognized link line: " + join(this->inputs));
+            DEBUG_LOG("Unrecognized link line: " + join(this->inputs));
         }
         return ToolChainInvocation::InvokeToolchain();
     }
@@ -135,13 +135,13 @@ DWORD LdInvocation::InvokeToolchain() {
         std::string const shorter_name = existing_coff.GetName();
         std::string const link_name = basename(link_run.get_out());
         if (shorter_name.empty() || link_name.empty()) {
-            debug("Cannot determine either PE or COFF names (Pe: " + link_name +
-                  "; Coff: " + shorter_name + ") skipping absolute rename\n");
+            DEBUG_LOG("Cannot determine either PE or COFF names (Pe: " + link_name +
+                      "; Coff: " + shorter_name + ") skipping absolute rename\n");
         }
 
         if (shorter_name != link_name) {
-            debug("internal lib name: " + shorter_name +
-                  " Pe name: " + link_name + " are not equivalent");
+            DEBUG_LOG("internal lib name: " + shorter_name +
+                      " Pe name: " + link_name + " are not equivalent");
             return 0;
         }
         existing_coff_reader.Close();
@@ -176,20 +176,20 @@ DWORD LdInvocation::InvokeToolchain() {
     }
     CoffReaderWriter coff_reader(abs_out_imp_lib_name);
     CoffParser coff(&coff_reader);
-    debug("Parsing COFF file: " + abs_out_imp_lib_name);
+    DEBUG_LOG("Parsing COFF file: " + abs_out_imp_lib_name);
     if (!coff.Parse()) {
-        debug("Failed to parse COFF file: " + abs_out_imp_lib_name);
+        DEBUG_LOG("Failed to parse COFF file: " + abs_out_imp_lib_name);
         return ExitConditions::COFF_PARSE_FAILURE;
     }
-    debug("COFF file parsed");
-    debug("Normalizing coff file for name: " + pe_name);
+    DEBUG_LOG("COFF file parsed");
+    DEBUG_LOG("Normalizing coff file for name: " + pe_name);
     if (!coff.NormalizeName(pe_name)) {
-        debug("Failed to normalize name for COFF file: " +
-              abs_out_imp_lib_name);
+        DEBUG_LOG("Failed to normalize name for COFF file: " +
+                  abs_out_imp_lib_name);
         return ExitConditions::NORMALIZE_NAME_FAILURE;
     }
-    debug("Renaming library from " + abs_out_imp_lib_name + " to " +
-          imp_lib_name);
+    DEBUG_LOG("Renaming library from " + abs_out_imp_lib_name + " to " +
+              imp_lib_name);
     if (!ReplaceFileWithRename(imp_lib_name, abs_out_imp_lib_name)) {
         return ExitConditions::FILE_RENAME_FAILURE;
     }

--- a/src/linker_invocation.cxx
+++ b/src/linker_invocation.cxx
@@ -160,7 +160,7 @@ void LinkerInvocation::processRSPFile(std::string const& rsp_file) {
     if (!rsp_stream) {
         std::cerr << "Error: Could not open input rsp file: " << rsp_file_in
                   << "\n";
-        throw FileIOError("Cannot open rsp input file: " + GetLastError());
+        throw FileIOError(("Cannot open rsp input file: " + std::to_string(GetLastError())).c_str());
     }
     std::string line;
     while (std::getline(rsp_stream, line)) {
@@ -187,8 +187,8 @@ void LinkerInvocation::processRSPFile(std::string const& rsp_file) {
  * input file for the lib tool
  */
 bool LinkerInvocation::makeRsp() {
-    int const total_length = std::accumulate(
-        this->input_files_.begin(), this->input_files_.end(), 0,
+    size_t const total_length = std::accumulate(
+        this->input_files_.begin(), this->input_files_.end(), size_t{0},
         [](size_t sum, const std::string& s) { return sum + s.size(); });
     if (total_length > MaxProcessCommandLength) {
         std::string const rsp_name = "spack-build.rsp";
@@ -226,7 +226,7 @@ void LinkerInvocation::processDefFile() {
     if (!def_in) {
         std::cerr << "Error: Could not open input def file: " << this->def_file_->file()
                   << "\n";
-        throw FileIOError("Cannot open def input file: " + GetLastError());
+        throw FileIOError(("Cannot open def input file: " + std::to_string(GetLastError())).c_str());
     }
 
     std::string line;
@@ -274,7 +274,7 @@ void LinkerInvocation::processDefFile() {
         if (!def_out) {
             std::cerr << "Error: could not open output def file: " << rename_def
                       << "\n";
-            throw FileIOError("Cannot open def output file: " + GetLastError());
+            throw FileIOError(("Cannot open def output file: " + std::to_string(GetLastError())).c_str());
         }
         for (const auto& line : exports) {
             def_out << line << "\n";

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -72,7 +72,7 @@ int main(int argc, const char* argv[]) {
             }
             return ExitConditions::SUCCESS;
         }
-        DEBUG = debug;
+        SetDebug(debug);
         std::unique_ptr<LibRename> rpath_lib;
         try {
             if (has_coff) {

--- a/src/regex_utils.h
+++ b/src/regex_utils.h
@@ -1,0 +1,52 @@
+/**
+ * Copyright Spack Project Developers. See COPYRIGHT file for details.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR MIT)
+ */
+#pragma once
+
+/**
+ * Regex helpers, kept out of utils.h so that <regex> - the heaviest header in
+ * the standard library - is only compiled into the translation units that
+ * actually match against text (currently just the relocation path).
+ */
+
+#include <regex>
+#include <string>
+#include <vector>
+
+/// @brief Searches a sections of a string for a given regex using provided
+///     options to control search behavior
+/// @param searchDomain - string to be searched
+/// @param regex - regex used to search
+/// @param opts - optional argument, list of regex tuning options to adapt the search behavior
+/// @return Character sequence matching search regex
+std::smatch regexSearch(
+    const std::string& searchDomain, const std::string& regex,
+    const std::vector<std::regex_constants::syntax_option_type>& opts = {},
+    const std::vector<std::regex_constants::match_flag_type>& flags = {});
+
+/// @brief Tries to match an entire string to a given regex using provided
+///     options to control match behavior
+/// @param searchDomain - string to be matched
+/// @param regex - regex used to match
+/// @param opts - optional argument, list of regex tuning options to adapt the match behavior
+/// @return Character sequence matching regex
+std::smatch regexMatch(
+    const std::string& searchDomain, const std::string& regex,
+    const std::vector<std::regex_constants::syntax_option_type>& opts = {},
+    const std::vector<std::regex_constants::match_flag_type>& flags = {});
+
+/// @brief Searches a string for a given regex using provided
+///     options to control search behavior, and if found, replaces
+///     discovered string with given replacement string
+/// @param searchDomain - string to be searched
+/// @param regex - regex used to search
+/// @param replacement - string used to replace regex matched result
+/// @param opts - optional argument, list of regex tuning options to adapt the search behavior
+/// @return Character sequence matching search regex
+std::string regexReplace(
+    const std::string& replaceDomain, const std::string& regex,
+    const std::string& replacement,
+    const std::vector<std::regex_constants::syntax_option_type>& opts = {},
+    const std::vector<std::regex_constants::match_flag_type>& flags = {});

--- a/src/spack_env.cxx
+++ b/src/spack_env.cxx
@@ -10,14 +10,14 @@ SpackEnvState SpackEnvState::LoadSpackEnvState() {
     // For list type env variables, a second argument of
     // " " denotes this is a space separated env list
     SpackEnvState spackenv = SpackEnvState();
-    spackenv.Spack = GetSpackEnv("SPACK");
-    spackenv.SpackInstDir = GetSpackEnv("SPACKINSTDIR");
     spackenv.SpackCC = GetSpackEnv("SPACK_CC");
     spackenv.SpackCXX = GetSpackEnv("SPACK_CXX");
     spackenv.SpackFC = GetSpackEnv("SPACK_FC");
     spackenv.SpackF77 = GetSpackEnv("SPACK_F77");
-    spackenv.SpackRoot = GetSpackEnv("SPACK_ROOT");
-    spackenv.AddDebugFlags = GetSpackEnv("SPACK_ADD_DEBUG_FLAGS");
+    spackenv.SpackLD = GetSpackEnv("SPACK_LD");
+    // TODO(johnwparent): nothing consumes these four - Spack's per-package
+    // compiler and linker flags never reach the tool command line. They are
+    // loaded here so the gap stays visible rather than silently disappearing.
     spackenv.SpackFFlags = GetEnvList("SPACK_FFLAGS", " ");
     spackenv.SpackCFlags = GetEnvList("SPACK_CFLAGS", " ");
     spackenv.SpackCxxFlags = GetEnvList("SPACK_CXXFLAGS", " ");
@@ -29,18 +29,6 @@ SpackEnvState SpackEnvState::LoadSpackEnvState() {
         GetEnvList("SPACK_COMPILER_IMPLICIT_RPATHS", "|");
     spackenv.SpackIncludeDirs = GetEnvList("SPACK_INCLUDE_DIRS", "|");
     spackenv.SpackLinkDirs = GetEnvList("SPACK_LINK_DIRS", "|");
-    spackenv.SpackCompilerFlagsKeep =
-        GetEnvList("SPACK_COMPILER_FLAGS_KEEP", "|");
-    spackenv.SpackCompilerFlagsReplace =
-        GetEnvList("SPACK_COMPILER_FLAGS_REPLACE", "|");
-    spackenv.SpackEnvPath = GetEnvList("SPACK_ENV_PATH");
-    spackenv.SpackCCRPathArg = GetSpackEnv("SPACK_CC_RPATH_ARG");
-    spackenv.SpackCXXRPathArg = GetSpackEnv("SPACK_CXX_RPATH_ARG");
-    spackenv.SpackFCRPathArg = GetSpackEnv("SPACK_FC_RPATH_ARG");
-    spackenv.SpackF77RPathArg = GetSpackEnv("SPACK_F77_RPATH_ARG");
-    spackenv.SpackSystemDirs = GetEnvList("SPACK_SYSTEM_DIRS", "|");
     spackenv.SpackRPathDirs = GetEnvList("SPACK_RPATH_DIRS", "|");
-    spackenv.SpackLinkerArg = GetSpackEnv("SPACK_LINKER_ARG");
-    spackenv.SpackLD = GetSpackEnv("SPACK_LD");
     return spackenv;
 }

--- a/src/spack_env.h
+++ b/src/spack_env.h
@@ -11,34 +11,32 @@
  * Loads Spack relevant variables from the environment
  * into the compiler wrapper for easy access
  * with convenient interface.
- * 
+ *
  * ENV variables that are lists are decomposed as such
  * by this method and are accessible as c++ lists
  * Variables that are simple strings are also treated as such
+ *
+ * This is loaded on every invocation of the wrapper, i.e. once per compiled
+ * source file, so it deliberately reads only what the wrapper consumes.
+ * Variables Spack sets that nothing here acts on are left unread rather than
+ * being fetched and split into vectors that are immediately discarded.
  */
 struct SpackEnvState {
-    std::string AddDebugFlags;
+    // NOTE: the four flag lists below are read from the environment but never
+    // applied to any command line. That is an unimplemented feature (Spack's
+    // per-package compiler flags are silently dropped), not dead weight -
+    // see the note in LoadSpackEnvState.
     StrList SpackFFlags;
     StrList SpackCFlags;
     StrList SpackCxxFlags;
     StrList SpackLdFlags;
+
     StrList SpackLdLibs;
     StrList SpackCompilerExtraRPaths;
     StrList SpackCompilerImplicitRPaths;
     StrList SpackIncludeDirs;
     StrList SpackLinkDirs;
-    StrList SpackCompilerFlagsKeep;
-    StrList SpackCompilerFlagsReplace;
-    StrList SpackEnvPath;
-    StrList SpackSystemDirs;
     StrList SpackRPathDirs;
-    std::string SpackCCRPathArg;
-    std::string SpackCXXRPathArg;
-    std::string SpackFCRPathArg;
-    std::string SpackF77RPathArg;
-    std::string SpackLinkerArg;
-    std::string Spack;
-    std::string SpackInstDir;
     std::string SpackCC;
     // SpackCXX is unused in the current implementation
     // but is left here for future compatibility with
@@ -46,7 +44,6 @@ struct SpackEnvState {
     std::string SpackCXX;
     std::string SpackFC;
     std::string SpackF77;
-    std::string SpackRoot;
     std::string SpackLD;
 
     /**

--- a/src/spack_env.h
+++ b/src/spack_env.h
@@ -24,7 +24,7 @@
 struct SpackEnvState {
     // NOTE: the four flag lists below are read from the environment but never
     // applied to any command line. That is an unimplemented feature (Spack's
-    // per-package compiler flags are silently dropped), not dead weight -
+    // per-package compiler flags are silently dropped)
     // see the note in LoadSpackEnvState.
     StrList SpackFFlags;
     StrList SpackCFlags;

--- a/src/toolchain.cxx
+++ b/src/toolchain.cxx
@@ -20,10 +20,16 @@ ToolChainInvocation::ToolChainInvocation(std::string command,
 }
 
 void ToolChainInvocation::InterpolateSpackEnv(SpackEnvState& spackenv) {
+    this->inputs.reserve(this->inputs.size() + spackenv.SpackIncludeDirs.size() +
+                         spackenv.SpackLdLibs.size() +
+                         spackenv.SpackLinkDirs.size() +
+                         spackenv.SpackRPathDirs.size() +
+                         spackenv.SpackCompilerExtraRPaths.size() +
+                         spackenv.SpackCompilerImplicitRPaths.size());
     // inject Spack includes before the default includes
     for (auto& include : spackenv.SpackIncludeDirs) {
-        auto inc_arg = ToolChainInvocation::ComposeIncludeArg(include);
-        this->inputs.push_back(inc_arg);
+        this->inputs.push_back(
+            ToolChainInvocation::ComposeIncludeArg(include));
     }
     for (auto& lib : spackenv.SpackLdLibs) {
         this->inputs.push_back(lib);
@@ -36,11 +42,26 @@ void ToolChainInvocation::InterpolateSpackEnv(SpackEnvState& spackenv) {
 }
 
 DWORD ToolChainInvocation::InvokeToolchain() {
+    if (this->command.empty()) {
+        std::cerr << "Spack compiler wrapper: no wrapped tool is configured "
+                     "in the environment\n";
+        return ExitConditions::INVALID_TOOLCHAIN;
+    }
+    if (IsSelf(this->command)) {
+        // Spawning this would spawn another wrapper, and another, until the
+        // machine runs out of processes. Fail loudly on the first one.
+        std::cerr << "Spack compiler wrapper: refusing to invoke itself. The "
+                     "environment points the wrapped tool at "
+                  << this->command
+                  << ", which is this wrapper. Set SPACK_CC/SPACK_CXX/SPACK_LD "
+                     "to the real toolchain executables.\n";
+        return ExitConditions::INVALID_TOOLCHAIN;
+    }
     quoteList(this->inputs);
     this->executor = ExecuteCommand(this->command, this->inputs);
-    debug("Setting up executor for " + std::string(typeid(*this).name()) +
-          "toolchain");
-    debug("Toolchain: " + this->command);
+    DEBUG_LOG("Setting up executor for " + std::string(typeid(*this).name()) +
+              "toolchain");
+    DEBUG_LOG("Toolchain: " + this->command);
     // Run first pass of command as requested by caller
     int const ret_code = static_cast<int>(this->executor.Execute());
     if (!ret_code) {
@@ -51,22 +72,26 @@ DWORD ToolChainInvocation::InvokeToolchain() {
 }
 
 void ToolChainInvocation::ParseCommandArgs(char const* const* cli) {
+    size_t argc = 0;
     for (char const* const* co = cli; *co; co++) {
-        const std::string arg = std::string(*co);
-        this->inputs.push_back(arg);
+        ++argc;
+    }
+    this->inputs.reserve(argc);
+    for (char const* const* co = cli; *co; co++) {
+        this->inputs.emplace_back(*co);
     }
 }
 
-std::string ToolChainInvocation::ComposeIncludeArg(std::string& include) {
+std::string ToolChainInvocation::ComposeIncludeArg(const std::string& include) {
     return "/external:I\"" + include + "\"";
 }
 
-std::string ToolChainInvocation::ComposeLibPathArg(std::string& libPath) {
+std::string ToolChainInvocation::ComposeLibPathArg(const std::string& libPath) {
     return "/LIBPATH:" + libPath;
 }
 
-void ToolChainInvocation::AddExtraLibPaths(StrList paths) {
-    for (auto& lib_dir : paths) {
+void ToolChainInvocation::AddExtraLibPaths(const StrList& paths) {
+    for (const auto& lib_dir : paths) {
         this->inputs.push_back(ToolChainInvocation::ComposeLibPathArg(lib_dir));
     }
 }

--- a/src/toolchain.h
+++ b/src/toolchain.h
@@ -24,9 +24,9 @@ class ToolChainInvocation {
    protected:
     virtual void ParseCommandArgs(char const* const* cli);
     virtual void LoadToolchainDependentSpackVars(SpackEnvState& spackenv) = 0;
-    static std::string ComposeIncludeArg(std::string& include);
-    static std::string ComposeLibPathArg(std::string& libPath);
-    void AddExtraLibPaths(StrList paths);
+    static std::string ComposeIncludeArg(const std::string& include);
+    static std::string ComposeLibPathArg(const std::string& libPath);
+    void AddExtraLibPaths(const StrList& paths);
     static StrList ComposeCommandLists(
         const std::vector<StrList>& command_args);
 

--- a/src/utils.cxx
+++ b/src/utils.cxx
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: (Apache-2.0 OR MIT)
  */
 #include "utils.h"
+#include "regex_utils.h"
 #include <aclapi.h>
 #include <accctrl.h>
 #include <errhandlingapi.h>
@@ -279,7 +280,7 @@ void lower(std::string& str) {
  * 
  *  Return the escaped string
  */
-std::string quoteAsNeeded(std::string& str) {
+void quoteAsNeeded(std::string& str) {
     // Note: the ordering if these two conditionals is important
     // If the second conditional is executed first, the first
     // will always be true as the second injects the string
@@ -291,18 +292,30 @@ std::string quoteAsNeeded(std::string& str) {
         // If there are escaped quotes in input
         // We need to escape them as well as we're adding another
         // layer of indirection between caller and compiler
-        std::regex const pattern("\"");
-        str = std::regex_replace(str, pattern, "\\\"");
+        // This runs for every argument of every invocation, so it is a plain
+        // scan rather than a regex - constructing a std::regex is one of the
+        // most expensive operations in the standard library
+        std::string escaped;
+        escaped.reserve(str.size() + 8);
+        for (char const chr : str) {
+            if (chr == '\"') {
+                escaped += '\\';
+            }
+            escaped += chr;
+        }
+        str = std::move(escaped);
     }
     if (str.find_first_of(" &<>|()") != std::string::npos) {
         // There are spaces or special characters in string, quote it
-        str = "\"" + str + "\"";
+        str.insert(str.begin(), '\"');
+        str += '\"';
     }
-    return str;
 }
 
 void quoteList(StrList& args) {
-    std::transform(args.begin(), args.end(), args.begin(), quoteAsNeeded);
+    for (std::string& arg : args) {
+        quoteAsNeeded(arg);
+    }
 }
 
 std::regex_constants::syntax_option_type composeRegexOptions(
@@ -384,6 +397,40 @@ std::string GetSpackEnv(const char* env) {
 }
 
 /**
+ * Reports whether the given command refers to this very executable.
+ *
+ * A misconfigured environment - SPACK_CC or SPACK_LD pointing at the wrapper
+ * rather than at the tool it wraps - otherwise produces an unbounded chain of
+ * wrapper processes, each spawning another, until the machine is exhausted.
+ * Comparison is a pure string operation on the fully qualified forms; no
+ * filesystem access is involved, so this is cheap enough for the hot path.
+ */
+bool IsSelf(const std::string& command) {
+    if (command.empty()) {
+        return false;
+    }
+    wchar_t self_path[MAX_PATH * 4];
+    DWORD const self_len =
+        GetModuleFileNameW(nullptr, self_path, ARRAYSIZE(self_path));
+    if (self_len == 0 || self_len >= ARRAYSIZE(self_path)) {
+        return false;
+    }
+    std::wstring wcommand;
+    try {
+        wcommand = ConvertASCIIToWide(command);
+    } catch (const std::overflow_error&) {
+        return false;
+    }
+    wchar_t full_command[MAX_PATH * 4];
+    DWORD const full_len = GetFullPathNameW(
+        wcommand.c_str(), ARRAYSIZE(full_command), full_command, nullptr);
+    if (full_len == 0 || full_len >= ARRAYSIZE(full_command)) {
+        return false;
+    }
+    return _wcsicmp(self_path, full_command) == 0;
+}
+
+/**
  * Given an environment variable name
  * return the corresponding environment variable value
  * or an empty string as appropriate
@@ -396,7 +443,7 @@ std::string GetSpackEnv(const std::string& env) {
  * Returns list of strings from environment variable value
  * representing a list delineated by delim argument
  */
-StrList GetEnvList(const std::string& envVar, const std::string& delim) {
+StrList GetEnvList(const char* envVar, const std::string& delim) {
     std::string const env_value = GetSpackEnv(envVar);
     if (!env_value.empty())
         return split(env_value, delim);
@@ -405,15 +452,15 @@ StrList GetEnvList(const std::string& envVar, const std::string& delim) {
 }
 
 bool ValidateSpackEnv() {
-    std::vector<std::string> const spack_env{
+    static const char* const spack_env[] = {
         "SPACK_COMPILER_WRAPPER_PATH", "SPACK_DEBUG_LOG_DIR",
         "SPACK_DEBUG_LOG_ID",          "SPACK_SHORT_SPEC",
         "SPACK_SYSTEM_DIRS",           "SPACK_MANAGED_DIRS"};
-    for (const auto& var : spack_env)
-        if (!getenv(var.c_str())) {
+    for (const char* var : spack_env)
+        if (!getenv(var)) {
             std::cerr
-                << var +
-                       " isn't set in the environment and is expected to be\n";
+                << var
+                << " isn't set in the environment and is expected to be\n";
             return false;
         }
     return true;
@@ -478,9 +525,24 @@ DWORD RvaToFileOffset(PIMAGE_SECTION_HEADER& section_header,
     return 0;
 }
 
+namespace {
+bool g_debug_forced = false;
+}  // namespace
+
+void SetDebug(bool enabled) {
+    g_debug_forced = enabled;
+}
+
+bool DebugEnabled() {
+    // The environment cannot change under a running process, so pay for the
+    // lookup once rather than on every message
+    static const bool env_enabled = getenv("SPACK_DEBUG_WRAPPER") != nullptr;
+    return g_debug_forced || env_enabled;
+}
+
 void debug(const std::string& dbgStmt) {
-    if (DEBUG || getenv("SPACK_DEBUG_WRAPPER")) {
-        std::cout << "DEBUG: " << dbgStmt << std::endl;
+    if (DebugEnabled()) {
+        std::cerr << "DEBUG: " << dbgStmt << std::endl;
     }
 }
 
@@ -553,7 +615,7 @@ char* pad_path(const char* pth, DWORD str_size, char padding_char,
     // If str_size > bsize we get inappropriate conversion
     // from signed to unsigned
     if (str_size > bsize) {
-        debug("Padding string is greater than max string size allowed");
+        DEBUG_LOG("Padding string is greater than max string size allowed");
         return nullptr;
     }
     size_t const extended_buf = bsize - str_size + 2;
@@ -637,9 +699,9 @@ std::string getSFN(const std::string& path, const bool make_file = false) {
         HANDLE h_file = CreateFileA(path.c_str(), GENERIC_WRITE, 0, nullptr,
                                     CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr);
         if (h_file == INVALID_HANDLE_VALUE) {
-            debug("File " + path +
-                  " does not exist, nor can it be created, unable to "
-                  "compute SFN\n");
+            DEBUG_LOG("File " + path +
+                      " does not exist, nor can it be created, unable to "
+                      "compute SFN\n");
             CloseHandle(h_file);
             return std::string();
         }
@@ -798,7 +860,7 @@ bool hasPathCharacters(const std::string& name) {
 bool SpackInstalledLib(const std::string& lib) {
     const std::string prefix = GetSpackEnv("SPACK_INSTALL_PREFIX");
     if (prefix.empty()) {
-        debug(
+        DEBUG_LOG(
             "Unable to determine Spack install prefix, SPACK_INSTALL_PREFIX "
             "unset");
         return false;
@@ -867,7 +929,7 @@ std::string PathRelocator::relocateBC(std::string const& pe) {
     }
     // Don't fail if we're relocating from a BC
     // Just warn
-    debug("Unable to find relocation mapping for library: " + pe);
+    DEBUG_LOG("Unable to find relocation mapping for library: " + pe);
     return pe;
 }
 
@@ -876,7 +938,7 @@ std::string PathRelocator::relocateStage(std::string const& pe) {
         std::string prefix_loc = this->old_new_map.at(pe);
         return prefix_loc;
     } catch (std::out_of_range& e) {
-        debug("Could not find path to " + pe + "in relocation mapping");
+        DEBUG_LOG("Could not find path to " + pe + "in relocation mapping");
         return std::string();
     }
 }
@@ -1185,8 +1247,8 @@ ScopedFile::~ScopedFile() {
         // The file having already been consumed (renamed away or never
         // produced) is the common success case, not a cleanup failure
         if (err != ERROR_FILE_NOT_FOUND && err != ERROR_PATH_NOT_FOUND) {
-            debug("Failed to remove temporary file " + file_path_ + ": " +
-                  reportLastError());
+            DEBUG_LOG("Failed to remove temporary file " + file_path_ + ": " +
+                      reportLastError());
         }
     }
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -12,7 +12,6 @@
 #include <cctype>
 #include <iostream>
 #include <map>
-#include <regex>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -65,8 +64,12 @@ typedef std::vector<std::string> StrList;
 // Environment Helper Methods
 std::string GetSpackEnv(const char* env);
 std::string GetSpackEnv(const std::string& env);
-StrList GetEnvList(const std::string& envVar, const std::string& delim = ";");
+StrList GetEnvList(const char* envVar, const std::string& delim = ";");
 bool ValidateSpackEnv();
+
+// Returns true if command resolves to the running executable, i.e. the
+// wrapper has been pointed at itself and would spawn itself forever
+bool IsSelf(const std::string& command);
 
 // String helper methods adding cxx20 features to cxx14 //
 
@@ -142,43 +145,7 @@ char* findstr(char* search_str, const char* substr, size_t size);
 // side effects on Windows
 void quoteList(StrList& args);
 
-std::string quoteAsNeeded(std::string& str);
-
-/// @brief Searches a sections of a string for a given regex using provided
-///     options to control search behavior
-/// @param searchDomain - string to be searched
-/// @param regex - regex used to search
-/// @param opts - optional argument, list of regex tuning options to adapt the search behavior
-/// @return Character sequence matching search regex
-std::smatch regexSearch(
-    const std::string& searchDomain, const std::string& regex,
-    const std::vector<std::regex_constants::syntax_option_type>& opts = {},
-    const std::vector<std::regex_constants::match_flag_type>& flags = {});
-
-/// @brief Tries to match an entire string to a given regex using provided
-///     options to control match behavior
-/// @param searchDomain - string to be matched
-/// @param regex - regex used to match
-/// @param opts - optional argument, list of regex tuning options to adapt the match behavior
-/// @return Character sequence matching regex
-std::smatch regexMatch(
-    const std::string& searchDomain, const std::string& regex,
-    const std::vector<std::regex_constants::syntax_option_type>& opts = {},
-    const std::vector<std::regex_constants::match_flag_type>& flags = {});
-
-/// @brief Searches a string for a given regex using provided
-///     options to control search behavior, and if found, replaces
-///     discovered string with given replacement string
-/// @param searchDomain - string to be searched
-/// @param regex - regex used to search
-/// @param replacement - string used to replace regex matched result
-/// @param opts - optional argument, list of regex tuning options to adapt the search behavior
-/// @return Character sequence matching search regex
-std::string regexReplace(
-    const std::string& replaceDomain, const std::string& regex,
-    const std::string& replacement,
-    const std::vector<std::regex_constants::syntax_option_type>& opts = {},
-    const std::vector<std::regex_constants::match_flag_type>& flags = {});
+void quoteAsNeeded(std::string& str);
 
 // FS/Path helpers //
 
@@ -278,9 +245,34 @@ DWORD ToLittleEndian(DWORD val);
 
 // Operating Utils //
 
+/**
+ * Returns true if debug reporting is on, either because the wrapper was
+ * invoked with --debug/-d or because SPACK_DEBUG_WRAPPER is set. The
+ * environment is consulted once per process, not once per message.
+ */
+bool DebugEnabled();
+
+// Forces debug reporting on regardless of the environment
+void SetDebug(bool enabled);
+
 void debug(const std::string& dbgStmt);
 
 void debug(char* dbgStmt, int len);
+
+/**
+ * Emits a debug message.
+ *
+ * Always prefer this over calling debug() directly: the wrapper runs once per
+ * compiled source file, and a bare debug() call still pays for building its
+ * message (string concatenation, typeid, whole command lines) even when
+ * reporting is off. This checks first and builds second.
+ */
+#define DEBUG_LOG(dbgStmt)          \
+    do {                            \
+        if (DebugEnabled()) {       \
+            debug(dbgStmt);         \
+        }                           \
+    } while (0)
 
 bool isCommandArg(const std::string& arg, const std::string& command);
 
@@ -408,5 +400,3 @@ class FileIOError : public std::runtime_error {
     FileIOError(char const* const message);
     virtual char const* what() const;
 };
-
-static bool DEBUG = false;

--- a/src/winrpath.cxx
+++ b/src/winrpath.cxx
@@ -14,6 +14,7 @@
 #include "coff_parser.h"
 #include "coff_reader_writer.h"
 #include "execute.h"
+#include "regex_utils.h"
 #include "utils.h"
 
 #include <fstream>
@@ -53,7 +54,7 @@ bool LibRename::SpackCheckForDll(const std::string& dll_path) {
 */
 bool LibRename::RenameDll(char* name_loc, const std::string& dll_path) {
     if (SpackInstalledLib(dll_path)) {
-        debug("Spack installed dll reference, no need to relocate");
+        DEBUG_LOG("Spack installed dll reference, no need to relocate");
         return true;
     }
     PathRelocator relocator;
@@ -195,9 +196,9 @@ bool LibRename::FindDllAndRename(HANDLE& pe_in) {
             import_table_offset +
             (import_image_descriptor->Name - rva_import_directory);
         std::string const str_dll_name = std::string(imported_dll);
-        debug("Considering library: " + str_dll_name + " for relocation");
+        DEBUG_LOG("Considering library: " + str_dll_name + " for relocation");
         if (LibRename::SpackCheckForDll(str_dll_name)) {
-            debug("Spack dll: " + str_dll_name);
+            DEBUG_LOG("Spack dll: " + str_dll_name);
             if (!LibRename::RenameDll(imported_dll, str_dll_name)) {
                 std::cerr << "Unable to relocate DLL reference: "
                           << str_dll_name << "\n";

--- a/test/bench_wrapper.ps1
+++ b/test/bench_wrapper.ps1
@@ -1,0 +1,235 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+<#
+.SYNOPSIS
+    Measures the overhead this wrapper adds to a compile.
+
+.DESCRIPTION
+    Reports two numbers that matter for build throughput:
+
+    1. The wrapper process' own CPU time for a single compile, next to that
+       compile's wall time. The wrapper does almost no work of its own, so
+       these should be orders of magnitude apart. If the wrapper's CPU time
+       tracks the child's wall time, the wrapper is burning a core while it
+       waits - which costs nothing visible at -j1 and roughly halves compiler
+       throughput at -jN.
+
+    2. Wall-clock for a batch of compiles at -j1 and at -j<cores>, through the
+       wrapper and directly. Per-invocation overhead shows up in the -j1
+       number; CPU contention shows up only in the -jN number.
+
+    Run from a Visual Studio Developer prompt.
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File test\bench_wrapper.ps1
+    powershell -ExecutionPolicy Bypass -File test\bench_wrapper.ps1 -Iterations 64
+#>
+
+[CmdletBinding()]
+param(
+    # Wrapper binary to measure; defaults to the cl.exe built at the repo root
+    [string] $Wrapper,
+    # Number of compiles in the batch runs
+    [int]    $Iterations = 32,
+    # Parallelism for the contended run; defaults to the machine's core count
+    [int]    $Jobs = 0,
+    # Working directory for generated sources and objects
+    [string] $WorkDir,
+    # The real MSVC compiler. Auto-detected from the toolchain install if not
+    # given; never guessed from bare PATH order, because picking a wrapper here
+    # makes the wrapper spawn a wrapper without bound.
+    [string] $RealCl
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+if (-not $Wrapper)  { $Wrapper = Join-Path $repoRoot 'cl.exe' }
+if (-not $WorkDir)  { $WorkDir = Join-Path $repoRoot 'tmp\bench' }
+if ($Jobs -le 0)    { $Jobs = [Environment]::ProcessorCount }
+
+if (-not (Test-Path $Wrapper)) {
+    throw "Wrapper not found at $Wrapper. Build it first: nmake /f Makefile cl.exe"
+}
+$Wrapper = (Resolve-Path $Wrapper).Path
+
+# ---------------------------------------------------------------------------
+# Locate the real compiler.
+#
+# This must positively identify the MSVC toolchain rather than just taking the
+# first cl.exe on PATH that is not $Wrapper: any *other* copy of the wrapper
+# would be accepted, and pointing the wrapper's SPACK_CC at a wrapper produces
+# an unbounded chain of processes.
+# ---------------------------------------------------------------------------
+function Test-IsMsvcCompiler {
+    param([string] $Path)
+    if (-not $Path -or -not (Test-Path $Path)) { return $false }
+    if ((Resolve-Path $Path).Path -ieq $Wrapper) { return $false }
+    # The genuine compiler lives under the toolchain's VC\Tools\MSVC tree; the
+    # wrapper never does
+    return $Path -imatch '\\VC\\Tools\\MSVC\\'
+}
+
+if ($RealCl) {
+    if (-not (Test-Path $RealCl)) { throw "-RealCl not found: $RealCl" }
+    $realCl = (Resolve-Path $RealCl).Path
+    if ((Resolve-Path $realCl).Path -ieq $Wrapper) {
+        throw "-RealCl is the wrapper itself; that would recurse without bound."
+    }
+} else {
+    $realCl = $null
+    if ($env:VCToolsInstallDir) {
+        $hostArch = if ([Environment]::Is64BitOperatingSystem) { 'Hostx64\x64' } else { 'Hostx86\x86' }
+        $candidate = Join-Path $env:VCToolsInstallDir "bin\$hostArch\cl.exe"
+        if (Test-IsMsvcCompiler $candidate) { $realCl = $candidate }
+    }
+    if (-not $realCl) {
+        foreach ($candidate in (& where.exe cl 2>$null)) {
+            if (Test-IsMsvcCompiler $candidate) { $realCl = $candidate; break }
+        }
+    }
+}
+if (-not $realCl) {
+    throw ("Could not positively identify the MSVC cl.exe. Run from a VS " +
+           "Developer prompt, or pass -RealCl <path>.")
+}
+Write-Host "Wrapper : $Wrapper"
+Write-Host "Real cl : $realCl"
+Write-Host "Jobs    : $Jobs   Iterations: $Iterations"
+Write-Host ""
+
+# ---------------------------------------------------------------------------
+# Minimal Spack environment - the wrapper refuses to run without these
+# ---------------------------------------------------------------------------
+$env:SPACK_CC                    = $realCl
+$env:SPACK_CXX                   = $realCl
+# Resolve the linker next to the compiler for the same reason: a bare
+# "link.exe" could resolve to a wrapper symlink
+$env:SPACK_LD                    = Join-Path (Split-Path -Parent $realCl) 'link.exe'
+$env:SPACK_COMPILER_WRAPPER_PATH = $repoRoot
+$env:SPACK_DEBUG_LOG_DIR         = $WorkDir
+$env:SPACK_DEBUG_LOG_ID          = 'BENCH'
+$env:SPACK_SHORT_SPEC            = 'bench%msvc'
+$env:SPACK_SYSTEM_DIRS           = $env:PATH
+$env:SPACK_MANAGED_DIRS          = $WorkDir
+# Debug reporting off - measure the wrapper, not the console
+Remove-Item Env:\SPACK_DEBUG_WRAPPER -ErrorAction SilentlyContinue
+
+if (Test-Path $WorkDir) { Remove-Item -Recurse -Force $WorkDir }
+New-Item -ItemType Directory -Path $WorkDir | Out-Null
+
+# A source heavy enough that the child runs for a noticeable interval; a
+# trivial file compiles too fast to show CPU contention.
+$sourcePath = Join-Path $WorkDir 'bench_tu.cxx'
+@'
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+template <typename T>
+struct Holder {
+    std::vector<T> items;
+    std::map<std::string, std::vector<T>> byName;
+    std::unordered_map<std::string, std::shared_ptr<T>> owned;
+    T total() const { return std::accumulate(items.begin(), items.end(), T{}); }
+    std::string describe() const {
+        std::ostringstream out;
+        for (const auto& item : items) { out << item << ","; }
+        return out.str();
+    }
+};
+
+template <int N>
+struct Chain { static int value() { return N + Chain<N - 1>::value(); } };
+template <>
+struct Chain<0> { static int value() { return 0; } };
+
+int bench_entry() {
+    Holder<int> a; Holder<double> b; Holder<long long> c;
+    a.items.assign(64, 1); b.items.assign(64, 1.5); c.items.assign(64, 2);
+    std::sort(a.items.begin(), a.items.end());
+    return static_cast<int>(a.total() + b.total() + c.total()) +
+           Chain<200>::value() +
+           static_cast<int>(a.describe().size() + b.describe().size());
+}
+'@ | Set-Content -Encoding ASCII $sourcePath
+
+function Invoke-Compile {
+    param([string] $Exe, [string] $ObjName)
+    $compileArgs = @('/c', '/EHsc', '/nologo', $sourcePath, "/Fo$(Join-Path $WorkDir $ObjName)")
+    $proc = Start-Process -FilePath $Exe -ArgumentList $compileArgs `
+                          -PassThru -NoNewWindow -Wait -WorkingDirectory $WorkDir
+    return $proc
+}
+
+# ---------------------------------------------------------------------------
+# 1. Wrapper CPU time vs. child wall time, single compile
+# ---------------------------------------------------------------------------
+Write-Host '--- Single compile: wrapper CPU vs. wall time ---'
+# warm the filesystem / compiler caches first
+Invoke-Compile -Exe $Wrapper -ObjName 'warm.obj' | Out-Null
+
+$sw = [Diagnostics.Stopwatch]::StartNew()
+$proc = Invoke-Compile -Exe $Wrapper -ObjName 'single.obj'
+$sw.Stop()
+$wrapperCpuMs = $proc.TotalProcessorTime.TotalMilliseconds
+$wallMs = $sw.Elapsed.TotalMilliseconds
+$ratio = if ($wallMs -gt 0) { $wrapperCpuMs / $wallMs } else { 0 }
+
+Write-Host ("  wall time            : {0,8:N1} ms" -f $wallMs)
+Write-Host ("  wrapper process CPU  : {0,8:N1} ms" -f $wrapperCpuMs)
+Write-Host ("  CPU / wall           : {0,8:P1}" -f $ratio)
+if ($ratio -gt 0.5) {
+    Write-Host "  -> The wrapper is burning a core while waiting on the child." -ForegroundColor Red
+} else {
+    Write-Host "  -> The wrapper is idle while the child runs." -ForegroundColor Green
+}
+Write-Host ''
+
+# ---------------------------------------------------------------------------
+# 2. Batch wall clock, serial and parallel, wrapper vs. direct
+# ---------------------------------------------------------------------------
+function Measure-Batch {
+    param([string] $Exe, [int] $Count, [int] $Parallel)
+    $running = New-Object System.Collections.ArrayList
+    $sw = [Diagnostics.Stopwatch]::StartNew()
+    for ($i = 0; $i -lt $Count; $i++) {
+        $compileArgs = @('/c', '/EHsc', '/nologo', $sourcePath,
+                         "/Fo$(Join-Path $WorkDir ("batch_$i.obj"))")
+        $p = Start-Process -FilePath $Exe -ArgumentList $compileArgs `
+                           -PassThru -NoNewWindow -WorkingDirectory $WorkDir
+        [void]$running.Add($p)
+        while ($running.Count -ge $Parallel) {
+            $done = $running | Where-Object { $_.HasExited }
+            if ($done) {
+                foreach ($d in $done) { [void]$running.Remove($d) }
+            } else {
+                [void]($running[0].WaitForExit(50))
+            }
+        }
+    }
+    foreach ($p in $running) { $p.WaitForExit() }
+    $sw.Stop()
+    return $sw.Elapsed.TotalSeconds
+}
+
+foreach ($parallel in @(1, $Jobs)) {
+    $label = if ($parallel -eq 1) { 'serial (-j1)' } else { "parallel (-j$parallel)" }
+    Write-Host "--- $Iterations compiles, $label ---"
+    $direct  = Measure-Batch -Exe $realCl  -Count $Iterations -Parallel $parallel
+    $wrapped = Measure-Batch -Exe $Wrapper -Count $Iterations -Parallel $parallel
+    $overhead = if ($direct -gt 0) { ($wrapped - $direct) / $direct } else { 0 }
+    Write-Host ("  direct   : {0,7:N2} s" -f $direct)
+    Write-Host ("  wrapped  : {0,7:N2} s" -f $wrapped)
+    Write-Host ("  overhead : {0,7:P1}" -f $overhead)
+    Write-Host ''
+}
+
+Write-Host "Artifacts left in $WorkDir"

--- a/test/bench_wrapper.ps1
+++ b/test/bench_wrapper.ps1
@@ -59,9 +59,8 @@ $Wrapper = (Resolve-Path $Wrapper).Path
 # Locate the real compiler.
 #
 # This must positively identify the MSVC toolchain rather than just taking the
-# first cl.exe on PATH that is not $Wrapper: any *other* copy of the wrapper
-# would be accepted, and pointing the wrapper's SPACK_CC at a wrapper produces
-# an unbounded chain of processes.
+# first cl.exe on PATH, pointing the wrapper's SPACK_CC at any wrapper from here
+# produces an unbounded chain of processes.
 # ---------------------------------------------------------------------------
 function Test-IsMsvcCompiler {
     param([string] $Path)
@@ -100,12 +99,9 @@ Write-Host "Real cl : $realCl"
 Write-Host "Jobs    : $Jobs   Iterations: $Iterations"
 Write-Host ""
 
-# ---------------------------------------------------------------------------
-# Minimal Spack environment - the wrapper refuses to run without these
-# ---------------------------------------------------------------------------
 $env:SPACK_CC                    = $realCl
 $env:SPACK_CXX                   = $realCl
-# Resolve the linker next to the compiler for the same reason: a bare
+# Resolve the linker next to the compiler, a bare
 # "link.exe" could resolve to a wrapper symlink
 $env:SPACK_LD                    = Join-Path (Split-Path -Parent $realCl) 'link.exe'
 $env:SPACK_COMPILER_WRAPPER_PATH = $repoRoot
@@ -114,7 +110,7 @@ $env:SPACK_DEBUG_LOG_ID          = 'BENCH'
 $env:SPACK_SHORT_SPEC            = 'bench%msvc'
 $env:SPACK_SYSTEM_DIRS           = $env:PATH
 $env:SPACK_MANAGED_DIRS          = $WorkDir
-# Debug reporting off - measure the wrapper, not the console
+
 Remove-Item Env:\SPACK_DEBUG_WRAPPER -ErrorAction SilentlyContinue
 
 if (Test-Path $WorkDir) { Remove-Item -Recurse -Force $WorkDir }
@@ -170,7 +166,7 @@ function Invoke-Compile {
 }
 
 # ---------------------------------------------------------------------------
-# 1. Wrapper CPU time vs. child wall time, single compile
+# Wrapper CPU time vs. child wall time, single compile
 # ---------------------------------------------------------------------------
 Write-Host '--- Single compile: wrapper CPU vs. wall time ---'
 # warm the filesystem / compiler caches first
@@ -194,7 +190,7 @@ if ($ratio -gt 0.5) {
 Write-Host ''
 
 # ---------------------------------------------------------------------------
-# 2. Batch wall clock, serial and parallel, wrapper vs. direct
+# Batch wall clock, serial and parallel, wrapper vs. direct
 # ---------------------------------------------------------------------------
 function Measure-Batch {
     param([string] $Exe, [int] $Count, [int] $Parallel)


### PR DESCRIPTION
Optimizes wrapper performance in a few primary ways:

* removes manual stdout/err capture and forwarding
rather than redirecting the toolchain child processes stdout/err to pipes we read from and write to the wrapper stdout for capture, we directly attach the child to the wrapper's stdout and avoid having to spin a cpu to pipe io streams.
* Uses `waitforsingleobject` instead of calling `GetExitCodeProcess` while waiting for the child object to return.
`GetExitCodeProcess` within our while loop introduces a busy wait loop vs allowing the scheduler to pause execution entirely, allowing for more concurrent processing and reducing parallel bottlenecks
* Builds with more compiler and linker optimizations
* uses more optimal data structures and types when appropriate
* When debugging, checks for debug before constructing debug string
* Reduces frivolous operations (like checking env variables we don't use)
* Pulls regex utils into its own header so the heavy `<regex>` header is only included in TUs that actually need it.


Adds a benchmarking test to be run whenever changes to multiprocessing/threading logic are made to ensure continued performant execution of the wrapper.